### PR TITLE
fix(cocoapods): fix to pass cocoapods podspec validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ For its [Digital section](https://www.decathlon.design/726f8c765/p/6145b2-overvi
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Decathlon/vitamin-ios.git", .upToNextMajor(from: "0.4.0"))
+    .package(url: "https://github.com/Decathlon/vitamin-ios.git", .exact("0.4.1"))
 ]
 ```
 
 ### Cocoapods
 ```ruby
-pod 'Vitamin'
+pod 'Vitamin', '= 0.4.1'
 ```
 
 ## Available elements

--- a/Sources/Vitamin/Foundations/Icons/Vitamix.swift
+++ b/Sources/Vitamin/Foundations/Icons/Vitamix.swift
@@ -470,7 +470,7 @@ public struct VitaminImageAsset {
   public fileprivate(set) var name: String
 
   public var image: UIImage {
-    let bundle = Bundle.module
+    let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
     let resultImage = UIImage(named: name, in: bundle, compatibleWith: nil)
     #elseif os(watchOS)
@@ -486,10 +486,22 @@ public struct VitaminImageAsset {
 public extension UIImage {
   convenience init?(asset: VitaminImageAsset) {
     #if os(iOS) || os(tvOS)
-    let bundle = Bundle.module
+    let bundle = BundleToken.bundle
     self.init(named: asset.name, in: bundle, compatibleWith: nil)
     #elseif os(watchOS)
     self.init(named: asset.name)
     #endif
   }
 }
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type

--- a/Sources/Vitamin/Foundations/Typography/Fonts.swift
+++ b/Sources/Vitamin/Foundations/Typography/Fonts.swift
@@ -48,7 +48,7 @@ public struct VitaminFontConvertible {
 
   fileprivate var url: URL? {
     // swiftlint:disable:next implicit_return
-    return Bundle.module.url(forResource: path, withExtension: nil)
+    return BundleToken.bundle.url(forResource: path, withExtension: nil)
   }
 }
 
@@ -61,3 +61,15 @@ public extension UIFont {
     self.init(name: font.name, size: size)
   }
 }
+
+// swiftlint:disable convenience_type
+private final class BundleToken {
+  static let bundle: Bundle = {
+    #if SWIFT_PACKAGE
+    return Bundle.module
+    #else
+    return Bundle(for: BundleToken.self)
+    #endif
+  }()
+}
+// swiftlint:enable convenience_type

--- a/Sources/Vitamin/Utils/SwiftGen/swiftgen.yml
+++ b/Sources/Vitamin/Utils/SwiftGen/swiftgen.yml
@@ -23,7 +23,6 @@ xcassets:
       params:
         enumName: Vitamix
         imageTypeName: VitaminImageAsset
-        bundle: Bundle.module
         publicAccess: true
         forceProvidesNamespaces: true
 
@@ -38,5 +37,4 @@ fonts:
         enumName: VitaminFontFamily
         fontTypeName: VitaminFontConvertible
         fontAliasName: VitaminPlatformFont
-        bundle: Bundle.module
         publicAccess: true

--- a/Vitamin.podspec
+++ b/Vitamin.podspec
@@ -16,5 +16,6 @@ Pod::Spec.new do |s|
   s.source           = { :git => 'https://github.com/Decathlon/vitamin-ios.git', :tag => s.version.to_s }
   s.source_files     = 'Sources/**/*.swift'
   s.resources        = 'Sources/**/*.{xcassets,ttf,xib}'
+  s.swift_version    = '5.3'
 
 end


### PR DESCRIPTION
Before pushing to cocoapods, we need to run `pod lib lint`
And this enlightened that.... the project does not compile if not in SPM context (typically, for Cocoapods)

To fix that, I had to :
- change the SwiftGen configuration for Fonts and Icons
- add the swift version in podspec (5.3)

The validation now passes, so once this PR merged, I will be able to push it to Cocoapods trunk repo

After discussion with @lauthieb , I also modified the README to encourage users to use an exact version of Vitamin in their project (with SPM and Cocoapods)