### PR TITLE
docs(readme): add new image adaptation for dark mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 <p align="center">
   <img
     width="300px"
-    src="https://user-images.githubusercontent.com/9600228/102414461-e3b92b00-3ff6-11eb-9c96-5f37c4d5e02c.png"
+    src="https://user-images.githubusercontent.com/9600228/102414461-e3b92b00-3ff6-11eb-9c96-5f37c4d5e02c.png#gh-light-mode-only"
+    alt="Vitamin Decathlon Design System logo" />
+  <img
+    width="300px"
+    src="https://user-images.githubusercontent.com/9600228/147513091-66fcc204-279b-4140-9be5-c16744c0f637.png#gh-dark-mode-only"
     alt="Vitamin Decathlon Design System logo" />
 </p>
 


### PR DESCRIPTION
## Changes description 🧑‍💻
<!--- Describe your changes in detail -->
Add new image adaptation for dark mode

Details: https://github.blog/changelog/2021-11-24-specify-theme-context-for-images-in-markdown/

## Before vs. after
![Capture d’écran 2021-12-28 à 00 28 50](https://user-images.githubusercontent.com/9600228/147513491-fd8222f9-a02f-4842-8e06-06fe9d0247a8.png)

## Light

![Capture d’écran 2021-12-28 à 00 20 27](https://user-images.githubusercontent.com/9600228/147513259-9dccd813-c62c-4b50-8935-d3665cb8a764.png)

## Dark

![Capture d’écran 2021-12-28 à 00 20 06](https://user-images.githubusercontent.com/9600228/147513261-3e067616-880a-4ebe-b01d-cc0b56d0f482.png)
