### PR TITLE
feat(shadows): add shadow foundation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,6 +31,7 @@ let package = Package(
                 "Components/TextField/README.md",
                 "Foundations/Colors/README.md",
                 "Foundations/Icons/README.md",
+                "Foundations/Shadows/README.md",
                 "Foundations/Typography/README.md"
             ],
             resources: [

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following foundations are available :
 |---------|-------------|---------------|
 |Colors   | Semantics and base colors of the Design System. | [Documentation](./Sources/Vitamin/Foundations/Colors#readme)|
 |Icons   | Set of icons usable in the Design System. | [Documentation](./Sources/Vitamin/Foundations/Icons#readme)|
+|Shadows   | Shadows applicable to any view in the Design System. | [Documentation](./Sources/Vitamin/Foundations/Shadows#readme)|
 |Typography | Text styles usable in the Design System. | [Documentation](./Sources/Vitamin/Foundations/Typography#readme)|
 
 

--- a/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.swift
+++ b/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.swift
@@ -7,15 +7,15 @@ import UIKit
 import Vitamin
 
 public class ShadowTableViewCell: UITableViewCell {
-    @IBOutlet weak var ibLabel: UILabel!
+    @IBOutlet weak var exampleLabel: UILabel!
 
     func update(for shadowType: VitaminShadow) {
-        ibLabel.removeShadow()
-        ibLabel.layer.cornerRadius = 20
-        ibLabel.backgroundColor = VitaminColor.Core.Background.accent
-        ibLabel.dropShadow(shadowType: shadowType)
+        exampleLabel.removeShadow()
+        exampleLabel.layer.cornerRadius = 20
+        exampleLabel.backgroundColor = VitaminColor.Core.Background.accent
+        exampleLabel.dropShadow(shadowType: shadowType)
 
-        ibLabel.attributedText = "This is a test label \nwith a \(shadowType.rawValue) shadow type".styled(as: .callout)
-        ibLabel.textAlignment = .center
+        exampleLabel.attributedText = "This is a test label \nwith a \(shadowType.rawValue) shadow type".styled(as: .callout)
+        exampleLabel.textAlignment = .center
     }
 }

--- a/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.swift
+++ b/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.swift
@@ -1,0 +1,21 @@
+//
+//  Vitamin iOS
+//  Apache License 2.0
+//
+
+import UIKit
+import Vitamin
+
+public class ShadowTableViewCell: UITableViewCell {
+    @IBOutlet weak var ibLabel: UILabel!
+
+    func update(for shadowType: VitaminShadowType) {
+        ibLabel.removeShadow()
+        ibLabel.layer.cornerRadius = 20
+        ibLabel.backgroundColor = VitaminColor.Core.Background.accent
+        ibLabel.dropShadow(shadowType: shadowType)
+
+        ibLabel.attributedText = "This is a test label \nwith a \(shadowType.rawValue) shadow type".styled(as: .callout)
+        ibLabel.textAlignment = .center
+    }
+}

--- a/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.swift
+++ b/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.swift
@@ -9,7 +9,7 @@ import Vitamin
 public class ShadowTableViewCell: UITableViewCell {
     @IBOutlet weak var ibLabel: UILabel!
 
-    func update(for shadowType: VitaminShadowType) {
+    func update(for shadowType: VitaminShadow) {
         ibLabel.removeShadow()
         ibLabel.layer.cornerRadius = 20
         ibLabel.backgroundColor = VitaminColor.Core.Background.accent

--- a/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.xib
+++ b/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.xib
@@ -34,7 +34,7 @@
                 </constraints>
             </tableViewCellContentView>
             <connections>
-                <outlet property="ibLabel" destination="G2W-Tt-v1K" id="pot-4N-e1y"/>
+                <outlet property="exampleLabel" destination="G2W-Tt-v1K" id="J0u-mZ-Cu6"/>
             </connections>
             <point key="canvasLocation" x="137.68115942028987" y="113.50446428571428"/>
         </tableViewCell>

--- a/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.xib
+++ b/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.xib
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" rowHeight="113" id="PoB-g5-nxs" customClass="ShadowTableViewCell" customModule="Showcase" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="414" height="113"/>
+            <autoresizingMask key="autoresizingMask"/>
+            <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" ambiguous="YES" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="PoB-g5-nxs" id="6cb-R6-3nu">
+                <rect key="frame" x="0.0" y="0.0" width="414" height="113"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is a test label" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="G2W-Tt-v1K">
+                        <rect key="frame" x="67" y="30" width="280" height="80"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="80" id="COJ-tE-WYd"/>
+                            <constraint firstAttribute="width" constant="280" id="OUE-20-Rwq"/>
+                        </constraints>
+                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                        <nil key="textColor"/>
+                        <nil key="highlightedColor"/>
+                    </label>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="G2W-Tt-v1K" firstAttribute="top" secondItem="6cb-R6-3nu" secondAttribute="top" constant="30" id="3jP-eG-rxH"/>
+                    <constraint firstAttribute="bottom" secondItem="G2W-Tt-v1K" secondAttribute="bottom" constant="60" id="QM8-4v-heo"/>
+                    <constraint firstItem="G2W-Tt-v1K" firstAttribute="centerX" secondItem="6cb-R6-3nu" secondAttribute="centerX" id="VRy-j9-PDZ"/>
+                </constraints>
+            </tableViewCellContentView>
+            <connections>
+                <outlet property="ibLabel" destination="G2W-Tt-v1K" id="pot-4N-e1y"/>
+            </connections>
+            <point key="canvasLocation" x="137.68115942028987" y="113.50446428571428"/>
+        </tableViewCell>
+    </objects>
+</document>

--- a/Showcase/Application/Foundations/Shadows/ShadowsViewController.swift
+++ b/Showcase/Application/Foundations/Shadows/ShadowsViewController.swift
@@ -1,0 +1,43 @@
+//
+//  Vitamin iOS
+//  Apache License 2.0
+//
+
+import UIKit
+import Vitamin
+
+final class ShadowsViewController: UITableViewController {
+    convenience init() {
+        self.init(style: .grouped)
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        navigationItem.title = "Button"
+        tableView.register(UINib(nibName: "ShadowTableViewCell", bundle: nil), forCellReuseIdentifier: "shadow")
+    }
+
+    var shadows: [VitaminShadowType] = [
+        .shadow100,
+        .shadow200,
+        .shadow300,
+        .shadow400
+    ]
+}
+
+extension ShadowsViewController {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        shadows.count
+    }
+
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: "shadow") as? ShadowTableViewCell else {
+                    let cell = ShadowTableViewCell(style: .default, reuseIdentifier: "shadow")
+                    return cell
+                }
+        cell.selectionStyle = .none
+        cell.update(for: shadows[indexPath.row])
+        return cell
+    }
+}

--- a/Showcase/Application/Foundations/Shadows/ShadowsViewController.swift
+++ b/Showcase/Application/Foundations/Shadows/ShadowsViewController.swift
@@ -18,7 +18,7 @@ final class ShadowsViewController: UITableViewController {
         tableView.register(UINib(nibName: "ShadowTableViewCell", bundle: nil), forCellReuseIdentifier: "shadow")
     }
 
-    var shadows: [VitaminShadowType] = [
+    var shadows: [VitaminShadow] = [
         .shadow100,
         .shadow200,
         .shadow300,

--- a/Showcase/Application/Main/MainTableViewController.swift
+++ b/Showcase/Application/Main/MainTableViewController.swift
@@ -64,6 +64,7 @@ extension MainTableViewController {
             MenuSection(name: "🌳 Foundations", items: [
                 MenuItem(name: "🎨 Colors", viewController: ColorsViewController()),
                 MenuItem(name: "🖼 Icons", viewController: IconsViewController()),
+                MenuItem(name: "🌘 Shadows", viewController: ShadowsViewController()),
                 MenuItem(name: "🖋 Typography", viewController: TypographyViewController())
             ]),
             MenuSection(name: "🧩 Components", items: [

--- a/Showcase/Vitamin Showcase.xcodeproj/project.pbxproj
+++ b/Showcase/Vitamin Showcase.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		65BD9F3D2768D06900EEDC0D /* IconCollectionViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 65BD9F3A2768D06900EEDC0D /* IconCollectionViewCell.xib */; };
 		65BD9F3E2768D06900EEDC0D /* IconCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BD9F3B2768D06900EEDC0D /* IconCollectionViewCell.swift */; };
 		65BD9F3F2768D06900EEDC0D /* IconsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65BD9F3C2768D06900EEDC0D /* IconsViewController.swift */; };
+		65D1B6692787422100C1560B /* ShadowsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D1B6652787422100C1560B /* ShadowsViewController.swift */; };
+		65D1B66A2787422100C1560B /* ShadowTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65D1B6672787422100C1560B /* ShadowTableViewCell.swift */; };
+		65D1B66B2787422100C1560B /* ShadowTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 65D1B6682787422100C1560B /* ShadowTableViewCell.xib */; };
 		AA68B4CB25681A5A00F1A4D7 /* ButtonTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA68B4CA25681A5A00F1A4D7 /* ButtonTableViewCell.swift */; };
 		AA68B4CE25681A6700F1A4D7 /* ButtonTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = AA68B4CD25681A6700F1A4D7 /* ButtonTableViewCell.xib */; };
 		AAB029CE256805A900F08C74 /* ColorsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAB029CD256805A900F08C74 /* ColorsViewController.swift */; };
@@ -44,6 +47,9 @@
 		65BD9F3A2768D06900EEDC0D /* IconCollectionViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IconCollectionViewCell.xib; sourceTree = "<group>"; };
 		65BD9F3B2768D06900EEDC0D /* IconCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IconCollectionViewCell.swift; sourceTree = "<group>"; };
 		65BD9F3C2768D06900EEDC0D /* IconsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IconsViewController.swift; sourceTree = "<group>"; };
+		65D1B6652787422100C1560B /* ShadowsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShadowsViewController.swift; sourceTree = "<group>"; };
+		65D1B6672787422100C1560B /* ShadowTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ShadowTableViewCell.swift; sourceTree = "<group>"; };
+		65D1B6682787422100C1560B /* ShadowTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ShadowTableViewCell.xib; sourceTree = "<group>"; };
 		AA68B4CA25681A5A00F1A4D7 /* ButtonTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonTableViewCell.swift; sourceTree = "<group>"; };
 		AA68B4CD25681A6700F1A4D7 /* ButtonTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ButtonTableViewCell.xib; sourceTree = "<group>"; };
 		AAB029CD256805A900F08C74 /* ColorsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorsViewController.swift; sourceTree = "<group>"; };
@@ -150,6 +156,7 @@
 		4AAD2B6B2767733500727D8E /* Foundations */ = {
 			isa = PBXGroup;
 			children = (
+				65D1B6642787422000C1560B /* Shadows */,
 				65BD9F382768D06900EEDC0D /* Icons */,
 				AAB029E725680D7500F08C74 /* Colors */,
 				AA68B4DB25683AF300F1A4D7 /* Typography */,
@@ -198,6 +205,24 @@
 			children = (
 				65BD9F3A2768D06900EEDC0D /* IconCollectionViewCell.xib */,
 				65BD9F3B2768D06900EEDC0D /* IconCollectionViewCell.swift */,
+			);
+			path = Cell;
+			sourceTree = "<group>";
+		};
+		65D1B6642787422000C1560B /* Shadows */ = {
+			isa = PBXGroup;
+			children = (
+				65D1B6652787422100C1560B /* ShadowsViewController.swift */,
+				65D1B6662787422100C1560B /* Cell */,
+			);
+			path = Shadows;
+			sourceTree = "<group>";
+		};
+		65D1B6662787422100C1560B /* Cell */ = {
+			isa = PBXGroup;
+			children = (
+				65D1B6672787422100C1560B /* ShadowTableViewCell.swift */,
+				65D1B6682787422100C1560B /* ShadowTableViewCell.xib */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -317,6 +342,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				65D1B66B2787422100C1560B /* ShadowTableViewCell.xib in Resources */,
 				AAC5D44D2567FE720070667D /* LaunchScreen.storyboard in Resources */,
 				65B52A1F273944DC008D9B5E /* SwitchTableViewCell.xib in Resources */,
 				651EF252272C0AD500121F7A /* TextFieldTableViewCell.xib in Resources */,
@@ -358,9 +384,11 @@
 			files = (
 				65BD9F3F2768D06900EEDC0D /* IconsViewController.swift in Sources */,
 				AAB029D1256805CC00F08C74 /* TypographyViewController.swift in Sources */,
+				65D1B6692787422100C1560B /* ShadowsViewController.swift in Sources */,
 				AAC5D4412567FE710070667D /* AppDelegate.swift in Sources */,
 				65B52A1D27394136008D9B5E /* SwitchTableViewCell.swift in Sources */,
 				4AAD2B67276772D200727D8E /* MainTableViewController.swift in Sources */,
+				65D1B66A2787422100C1560B /* ShadowTableViewCell.swift in Sources */,
 				AAB029CE256805A900F08C74 /* ColorsViewController.swift in Sources */,
 				AAB029D4256805E200F08C74 /* ButtonsViewController.swift in Sources */,
 				65B52A1927392EDD008D9B5E /* SwitchViewController.swift in Sources */,

--- a/Sources/Vitamin/Foundations/Shadows/README.md
+++ b/Sources/Vitamin/Foundations/Shadows/README.md
@@ -1,0 +1,40 @@
+## Shadows
+[Reference](https://www.decathlon.design/726f8c765/p/5522fa-shadows/b/69ed0e)
+
+Vitamin provides you with the `VitaminShadowType`enum, which has five possible cases :
+- `.shadow100`
+- `.shadow200`
+- `.shadow300`
+- `.shadow400`
+- `.none`
+
+To apply a shadow to any view, you can call the `dropShadow(shadowType: VitaminShadowType)` method on this view.
+
+```swift
+import Vitamin
+
+let label = UILabel.init(
+    frame: CGRect(
+        origin: .zero,
+        size: CGSize(width: 200, height: 80)
+    )
+)
+label.text = "Test label"
+label.layer.cornerRadius = 16
+
+// this label will have a shadow dropped
+label.dropShadow(shadowType: .shadow200)
+```
+
+In case you would like to remove a shadow you added before, you can call `removeShadow()` method on your view.
+
+```swift
+label.removeShadow()
+```
+
+**Notes**: 
+- Calling `removeShadow()` is equivalent to calling `dropShadow(shadowType: .none)`
+- These methods reset all the properties of the layer that are modified by `dropShadow(shadowType: VitaminShadowType)`, its usage could lead to strange behavior if used on a view whose shadow was not added by this method
+- 
+
+

--- a/Sources/Vitamin/Foundations/Shadows/README.md
+++ b/Sources/Vitamin/Foundations/Shadows/README.md
@@ -13,7 +13,7 @@ To apply a shadow to any view, you can call the `dropShadow(shadowType: VitaminS
 ```swift
 import Vitamin
 
-let label = UILabel.init(
+let label = UILabel(
     frame: CGRect(
         origin: .zero,
         size: CGSize(width: 200, height: 80)

--- a/Sources/Vitamin/Foundations/Shadows/README.md
+++ b/Sources/Vitamin/Foundations/Shadows/README.md
@@ -1,14 +1,14 @@
 ## Shadows
 [Reference](https://www.decathlon.design/726f8c765/p/5522fa-shadows/b/69ed0e)
 
-Vitamin provides you with the `VitaminShadowType`enum, which has five possible cases :
+Vitamin provides you with the `VitaminShadow`enum, which has five possible cases :
 - `.shadow100`
 - `.shadow200`
 - `.shadow300`
 - `.shadow400`
 - `.none`
 
-To apply a shadow to any view, you can call the `dropShadow(shadowType: VitaminShadowType)` method on this view.
+To apply a shadow to any view, you can call the `dropShadow(shadowType: VitaminShadow)` method on this view.
 
 ```swift
 import Vitamin
@@ -34,7 +34,7 @@ label.removeShadow()
 
 **Notes**: 
 - Calling `removeShadow()` is equivalent to calling `dropShadow(shadowType: .none)`
-- These methods reset all the properties of the layer that are modified by `dropShadow(shadowType: VitaminShadowType)`, its usage could lead to strange behavior if used on a view whose shadow was not added by this method
+- These methods reset all the properties of the layer that are modified by `dropShadow(shadowType: VitaminShadow)`, its usage could lead to strange behavior if used on a view whose shadow was not added by this method
 - 
 
 

--- a/Sources/Vitamin/Foundations/Shadows/Shadows.swift
+++ b/Sources/Vitamin/Foundations/Shadows/Shadows.swift
@@ -5,7 +5,7 @@
 
 import UIKit
 
-public enum VitaminShadowType: String {
+public enum VitaminShadow: String {
     case shadow100
     case shadow200
     case shadow300
@@ -61,10 +61,10 @@ public enum VitaminShadowType: String {
 
 extension UIView {
     /// Drops a shadow below this view.
-    /// - Parameters shadowType : the `VitaminShadowType`you wqnt to drop
+    /// - Parameters shadowType : the `VitaminShadow`you wqnt to drop
     /// Since the shadow os added to the layer of the view, the background color is
     /// forwarded from the view to the view'layer not to overlay the shadow
-    public func dropShadow(shadowType: VitaminShadowType) {
+    public func dropShadow(shadowType: VitaminShadow) {
         layer.applyShadow(
             color: shadowType.color,
             opacity: shadowType.opacity,

--- a/Sources/Vitamin/Foundations/Shadows/Shadows.swift
+++ b/Sources/Vitamin/Foundations/Shadows/Shadows.swift
@@ -30,8 +30,8 @@ public enum VitaminShadow: String {
 
     /// Size of the shadow, i.e. offset of the light source creating the shadow
     var size: CGSize {
-        // In fact, in Vitamin, the blur always equals to the height, we reuse the property to avoid dupliication
-        // If this changes in the fiture, we will just have to provide the independant value
+        // In fact, in Vitamin, the blur always equals to the height, we reuse the property to avoid duplication
+        // If this changes in the future, we will just have to provide the independant value
         CGSize(width: 0, height: self.blur)
     }
 

--- a/Sources/Vitamin/Foundations/Shadows/Shadows.swift
+++ b/Sources/Vitamin/Foundations/Shadows/Shadows.swift
@@ -12,7 +12,7 @@ public enum VitaminShadow: String {
     case shadow400
     case none
 
-    /// blur value of the shadow, and height
+    /// Blur value of the shadow, and height
     var blur: CGFloat {
         switch self {
         case .shadow100:
@@ -28,7 +28,7 @@ public enum VitaminShadow: String {
         }
     }
 
-    /// size of the shadow, i.e. offset of the light source creating the shadow
+    /// Size of the shadow, i.e. offset of the light source creating the shadow
     var size: CGSize {
         // In fact, in Vitamin, the blur always equals to the height, we reuse the property to avoid dupliication
         // If this changes in the fiture, we will just have to provide the independant value
@@ -36,12 +36,12 @@ public enum VitaminShadow: String {
     }
 
     /// Spread value of the shadow
-    /// Always 0 at the lmoment, but could evolve, that is why this property exists
+    /// Always 0 at the moment, but could evolve, that is why this property exists
     var spread: CGFloat {
         0
     }
 
-    /// opacity of the shadow
+    /// Opacity of the shadow
     var opacity: Float {
         if self == .none {
             return 0
@@ -49,13 +49,13 @@ public enum VitaminShadow: String {
         return 1
     }
 
-    /// color of the shadow
-    /// It is not a VitamoinColor, and s the same for dark and light mode
+    /// Color of the shadow
+    /// For the moment, it is the same for dark and light mode
     var color: UIColor {
         if self == .none {
             return UIColor.clear
         }
-        return UIColor(red: 0, green: 0.325, blue: 0.49, alpha: 0.1)
+        return VitaminColor.Base.blue600.color.withAlphaComponent(0.1)
     }
 }
 

--- a/Sources/Vitamin/Foundations/Shadows/Shadows.swift
+++ b/Sources/Vitamin/Foundations/Shadows/Shadows.swift
@@ -1,0 +1,122 @@
+//
+//  Vitamin iOS
+//  Apache License 2.0
+//
+
+import UIKit
+
+public enum VitaminShadowType: String {
+    case shadow100
+    case shadow200
+    case shadow300
+    case shadow400
+    case none
+
+    /// blur value of the shadow, and height
+    var blur: CGFloat {
+        switch self {
+        case .shadow100:
+            return 6
+        case .shadow200:
+            return 12
+        case .shadow300:
+            return 24
+        case .shadow400:
+            return 48
+        case .none:
+            return 0
+        }
+    }
+
+    /// size of the shadow, i.e. offset of the light source creating the shadow
+    var size: CGSize {
+        // In fact, in Vitamin, the blur always equals to the height, we reuse the property to avoid dupliication
+        // If this changes in the fiture, we will just have to provide the independant value
+        CGSize(width: 0, height: self.blur)
+    }
+
+    /// Spread value of the shadow
+    /// Always 0 at the lmoment, but could evolve, that is why this property exists
+    var spread: CGFloat {
+        0
+    }
+
+    /// opacity of the shadow
+    var opacity: Float {
+        if self == .none {
+            return 0
+        }
+        return 1
+    }
+
+    /// color of the shadow
+    /// It is not a VitamoinColor, and s the same for dark and light mode
+    var color: UIColor {
+        if self == .none {
+            return UIColor.clear
+        }
+        return UIColor(red: 0, green: 0.325, blue: 0.49, alpha: 0.1)
+    }
+}
+
+extension UIView {
+    /// Drops a shadow below this view.
+    /// - Parameters shadowType : the `VitaminShadowType`you wqnt to drop
+    /// Since the shadow os added to the layer of the view, the background color is
+    /// forwarded from the view to the view'layer not to overlay the shadow
+    public func dropShadow(shadowType: VitaminShadowType) {
+        layer.applyShadow(
+            color: shadowType.color,
+            opacity: shadowType.opacity,
+            shadowSize: shadowType.size,
+            blur: shadowType.blur,
+            spread: shadowType.spread)
+
+        if let backgroundCGColor = backgroundColor?.cgColor, shadowType != .none {
+            backgroundColor = nil
+            layer.backgroundColor = backgroundCGColor
+        }
+    }
+
+    /// Remove any shadow from this view by resetting all shadow properties on the view's layer
+    /// The layer background color is set back to the view if the layer color is not nil and the view's one is nil
+    public func removeShadow() {
+        dropShadow(shadowType: .none)
+
+        if let backgroundCGColor = backgroundColor?.cgColor, backgroundColor == nil {
+            layer.backgroundColor = nil
+            backgroundColor = UIColor(cgColor: backgroundCGColor)
+        }
+    }
+}
+
+extension CALayer {
+    /// Convenience mathod to apply a shadow on a CALayer
+    /// - Parameters:
+    ///     - color: the `UIColor` of the shadow
+    ///     - opacity: the opacity of the shadow
+    ///     - shadowSize: a `CGSize`defining the position of the light source
+    ///     - blur: blur of the shadow, as defined in Figma
+    ///     - spread: spread of the shadow, as defined in Figma
+    func applyShadow(
+        color: UIColor = .black,
+        opacity: Float = 0.5,
+        shadowSize: CGSize = CGSize(width: 0, height: 2),
+        blur: CGFloat = 4,
+        spread: CGFloat = 0
+    ) {
+            masksToBounds = false
+            shadowColor = color.cgColor
+            shadowOpacity = opacity
+            shadowOffset = shadowSize
+            // the shadow radius in iOS is equals to the blur divided by the screen scale
+            shadowRadius = blur / UIScreen.main.scale
+            if spread == 0 {
+                shadowPath = nil
+            } else {
+                let deltaX = -spread
+                let rect = bounds.insetBy(dx: deltaX, dy: deltaX)
+                shadowPath = UIBezierPath(rect: rect).cgPath
+            }
+    }
+}


### PR DESCRIPTION
### Changes description ###
Here is a proposal for shadow implementatiion.

I had to do a little research because the snippet generated by Figma was irrelevant.
Indeed, Figma uses notion of blur ans spread, which are not native for iOS.

I found some blog post about converting blur and spread from Sketch to iOS, and their method seems to work also for Figma.

I provided a quick README for shadows, and referenced this file in general README

### Showcase ###
The Showcase has been updated, with an example of shadow dropped under a rounded rect label, with Background.accent color. But the shadow should be applicable to any UIView.
![Simulator Screen Shot - iPhone 12 Pro Max - 2022-01-10 at 10 19 01](https://user-images.githubusercontent.com/43171132/148743768-fe5306ff-0791-44d5-88d8-ade36608e3cd.png)


### Remarks ###
The color of the shadow is the same for dark and light themes (could not find in Figma if I should use a specific color for dark theme), thus, the shadow is quite invisible in dark theme over a black background.