### PR TITLE
docs(.github): add configuration files

### DIFF
--- a/.github/ISSUE_TEMPLATE/CODEOWNERS
+++ b/.github/ISSUE_TEMPLATE/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, they will be
+# requested for review when someone opens a Pull Request.
+* @lauthieb @baptistedajon @florentlotthepro @daniel-dumortier

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,7 +38,7 @@ labels: bug 🐛
 **Screenshots**
 <!-- If applicable, add screenshots to help explain your problem. -->
 
-**Smartphone (please complete the following information):**
-- Device: [e.g. One Plus]
-- OS: [e.g. Lollipop]
-- Version [e.g. 21]
+**Device (please complete the following information):**
+- Model: [e.g. iPhone 12 or iPad Air 3]
+- OS: [e.g. iOS or iPadOS]
+- Version [e.g. 15.2]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,16 +35,10 @@ labels: bug 🐛
 **Expected behavior**
 <!-- A clear and concise description of what you expected to happen. -->
 
-**Browsers affected**
+**Screenshots**
+<!-- If applicable, add screenshots to help explain your problem. -->
 
-<!-- Choose your browser(s):
-    - Chrome
-    - Firefox
-    - Edge
-    - Safari
--->
-
-**Version affected**
-<!--
-@vtmn/...: vX.X.X
--->
+**Smartphone (please complete the following information):**
+- Device: [e.g. One Plus]
+- OS: [e.g. Lollipop]
+- Version [e.g. 21]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,50 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: 'bug: '
+labels: bug 🐛
+---
+
+<!-- 
+    Before submitting an issue, please consult our [documentation](https://decathlon.design). 
+    Please make sure you are posting an issue pertaining to the Decathlon Design System. 
+
+    Note that before opening an issue, you can chat maintainer of this project on channel
+    #vitamin-ios in [Decathlon Design System's Slack(https://join.slack.com/t/decathlon-design/shared_invite/zt-ou0n9qas-n_oamDSVUIqvLqNO1LETJg).
+
+    If you want to know how to contribute to this project, you can check our CONTRIBUTING file:
+    https://github.com/Decathlon/vitamin-ios/blob/main/CONTRIBUTING.md
+
+    If a section isn't adapted for your request, please remove it to avoid any unnecessary section.
+
+    Thanks!
+-->
+
+**Describe the bug**
+<!-- A clear and concise description of what the bug is. -->
+
+**Steps to reproduce**
+<!--
+    Steps to reproduce the behavior:
+    1. Go to '...'
+    2. Click on '....'
+    3. Scroll down to '....'
+    4. See error
+-->
+
+**Expected behavior**
+<!-- A clear and concise description of what you expected to happen. -->
+
+**Browsers affected**
+
+<!-- Choose your browser(s):
+    - Chrome
+    - Firefox
+    - Edge
+    - Safari
+-->
+
+**Version affected**
+<!--
+@vtmn/...: vX.X.X
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_improvements_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_improvements_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature or improvements request
+about: Suggest an idea for this project
+title: 'feat: '
+labels: enhancement 🚀
+---
+
+<!-- 
+    Before submitting an issue, please consult our [documentation](https://decathlon.design). 
+    Please make sure you are posting an issue pertaining to the Decathlon Design System. 
+
+    Note that before opening an issue, you can chat maintainer of this project on channel
+    #vitamin-ios in [Decathlon Design System's Slack(https://join.slack.com/t/decathlon-design/shared_invite/zt-ou0n9qas-n_oamDSVUIqvLqNO1LETJg).
+
+    If you want to know how to contribute to this project, you can check our CONTRIBUTING file:
+    https://github.com/Decathlon/vitamin-ios/blob/main/CONTRIBUTING.md
+
+    If a section isn't adapted for your request, please remove it to avoid any unnecessary section.
+
+    Thanks!
+-->
+
+**Is your request related to a problem? Please describe.**
+<!-- A clear and concise description of what the problem is. Ex. I'm always frustrated when [...] -->
+
+**Describe the solution you'd like**
+<!-- A clear and concise description of what you want to happen. -->
+
+**Additional context**
+<!-- Add any other context or screenshots about the feature request here. -->

--- a/.github/ISSUE_TEMPLATE/new_component_request.md
+++ b/.github/ISSUE_TEMPLATE/new_component_request.md
@@ -1,0 +1,37 @@
+---
+name: New component request
+about: Suggest a component for this project
+title: 'feat: add [component name] component'
+labels: enhancement 🚀
+---
+
+<!-- 
+    Before submitting an issue, please consult our [documentation](https://decathlon.design). 
+    Please make sure you are posting an issue pertaining to the Decathlon Design System. 
+
+    Note that before opening an issue, you can chat maintainer of this project on channel
+    #vitamin-ios in [Decathlon Design System's Slack(https://join.slack.com/t/decathlon-design/shared_invite/zt-ou0n9qas-n_oamDSVUIqvLqNO1LETJg).
+
+    If you want to know how to contribute to this project, you can check our CONTRIBUTING file:
+    https://github.com/Decathlon/vitamin-ios/blob/main/CONTRIBUTING.md
+
+    If a section isn't adapted for your request, please remove it to avoid any unnecessary section.
+
+    Thanks!
+-->
+
+**New component**
+<!-- A clear and concise description of what the feature request is. Please include if your feature request is related to a problem. -->
+
+**Documentation links**
+
+- [Documentation](https://decathlon.design/...)
+- [Figma](https://figma.com/...)
+
+**Checklist**
+<!-- Please, don't modify this checklist. -->
+
+- [ ] CSS
+- [ ] React
+- [ ] Svelte
+- [ ] Vue

--- a/.github/ISSUE_TEMPLATE/new_component_request.md
+++ b/.github/ISSUE_TEMPLATE/new_component_request.md
@@ -28,10 +28,3 @@ labels: enhancement 🚀
 - [Documentation](https://decathlon.design/...)
 - [Figma](https://figma.com/...)
 
-**Checklist**
-<!-- Please, don't modify this checklist. -->
-
-- [ ] CSS
-- [ ] React
-- [ ] Svelte
-- [ ] Vue

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,13 +8,12 @@
 ## Checklist
 <!--- Feel free to add other steps if needed. -->
 
-- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
-- [ ] Check the commit's or even all commits' message styles matches our requested structure.
+- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request your main!
+- [ ] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
 - [ ] Check your code additions will fail neither code linting checks.
-- [ ] Check PR name, it must follow the https://www.conventionalcommits.org pattern.
-- [ ] I have reviewed the submitted code
-- [ ] I have tested on a phone device/emulator
-- [ ] I have tested on a tablet device/emulator
+- [ ] I have reviewed the submitted code.
+- [ ] I have tested on a phone device/emulator.
+- [ ] I have tested on a tablet device/emulator.
 - [ ] If it's a new component, please ask for design review.
 
 ## Does this introduce a breaking change?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,8 +30,5 @@
 #### iPad
 <!--- Put your iPad screenshots here. -->
 
-#### Large screen
-<!--- Put your large screen screenshots here. -->
-
 ## Other information
 <!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,8 +12,8 @@
 - [ ] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
 - [ ] Check your code additions will fail neither code linting checks.
 - [ ] I have reviewed the submitted code.
-- [ ] I have tested on a phone device/emulator.
-- [ ] I have tested on a tablet device/emulator.
+- [ ] I have tested on an iPhone device/simulator.
+- [ ] I have tested on an iPad device/simulator.
 - [ ] If it's a new component, please ask for design review.
 
 ## Does this introduce a breaking change?
@@ -24,11 +24,11 @@
 
 ## Screenshots
 
-#### Phone
-<!--- Put your phone screenshots here. -->
+#### iPhone
+<!--- Put your iPhone screenshots here. -->
 
-#### Tablet
-<!--- Put your tablet screenshots here. -->
+#### iPad
+<!--- Put your iPad screenshots here. -->
 
 #### Large screen
 <!--- Put your large screen screenshots here. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,18 +6,33 @@
 <!--- If it fixes an opened issue, please link to the issue here. -->
 
 ## Checklist
+<!--- Feel free to add other steps if needed. -->
 
 - [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
 - [ ] Check the commit's or even all commits' message styles matches our requested structure.
 - [ ] Check your code additions will fail neither code linting checks.
 - [ ] Check PR name, it must follow the https://www.conventionalcommits.org pattern.
-- [ ] If it's a new component in CSS, please ask for design review.
+- [ ] I have reviewed the submitted code
+- [ ] I have tested on a phone device/emulator
+- [ ] I have tested on a tablet device/emulator
+- [ ] If it's a new component, please ask for design review.
 
 ## Does this introduce a breaking change?
 <!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
 
 - Yes
 - No
+
+## Screenshots
+
+#### Phone
+<!--- Put your phone screenshots here. -->
+
+#### Tablet
+<!--- Put your tablet screenshots here. -->
+
+#### Large screen
+<!--- Put your large screen screenshots here. -->
 
 ## Other information
 <!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Changes description
+<!--- Describe your changes in details. -->
+
+## Context
+<!--- Why is this change required? What problem does it solve? -->
+<!--- If it fixes an opened issue, please link to the issue here. -->
+
+## Checklist
+
+- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
+- [ ] Check the commit's or even all commits' message styles matches our requested structure.
+- [ ] Check your code additions will fail neither code linting checks.
+- [ ] Check PR name, it must follow the https://www.conventionalcommits.org pattern.
+- [ ] If it's a new component in CSS, please ask for design review.
+
+## Does this introduce a breaking change?
+<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
+
+- Yes
+- No
+
+## Other information
+<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->

--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,2 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,10 +10,10 @@ So, **thanks a lot for this**!! :tada::+1:
   - [Local development](#local-development)
   - [Code of conduct](#code-of-conduct)
   - [What are you talking about? Pull Request? Merge? Push?](#what-are-you-talking-about-pull-request-merge-push)
-  - [How Can I contribute?](#how-can-i-contribute)
-    - [Reporting Bug](#reporting-bug)
-    - [Code Contribution](#code-contribution)
-      - [Commit and Push on your branch](#commit-and-push-on-your-branch)
+  - [How can I contribute?](#how-can-i-contribute)
+    - [Reporting an issue](#reporting-an-issue)
+    - [Code contribution](#code-contribution)
+      - [Commit and push on your branch](#commit-and-push-on-your-branch)
     - [Pull Request guidelines](#pull-request-guidelines)
     - [Contribution acceptance criteria](#contribution-acceptance-criteria)
 
@@ -69,11 +69,11 @@ This project and everyone participating in it is governed by the [following code
 
 If you are not familiar with Git and GitHub terms you can check a complete [glossary](https://help.github.com/articles/github-glossary/) on the GitHub website.
 
-## How Can I contribute?
+## How can I contribute?
 
-### Reporting Bug
+### Reporting an issue
 
-The first way to contribute to a project is simply reporting a Bug. If you find anything which is not working well or as expected you can [open an issue](https://github.com/Decathlon/vitamin-ios/issues) repository.
+The first way to contribute to a project is simply proposing an issue. If you find anything which is not working well or as expected you can [open an issue](https://github.com/Decathlon/vitamin-ios/issues/new/choose).
 
 Before to open the issue please check if there is one similar already opened. It will save us hours of work and it will allow us to answer you quickly with the desired hotfix or implementation.
 
@@ -81,7 +81,7 @@ Before to open the issue please check if there is one similar already opened. It
 
 When you are opening an issue, please be sure to report as much information as you can to allow us to replicate the problem and faster find the solution.
 
-### Code Contribution
+### Code contribution
 
 If you are a dev and you want to directly fix a problem or implement a new feature... you are the best one ! :clap::clap:
 To propose any change you have to submit us a [Pull Request](https://help.github.com/articles/about-pull-requests/)
@@ -95,7 +95,7 @@ The workflow we are using the one-pay project is:
 We will take the time to review your code, make some comments or asking information if needed. But, as you took time to help us, we will take in serious consideration what you are proposing.
 To quickly have your code available on production, please take care and read our [Contribution acceptance criteria](#contribution-acceptance-criteria)
 
-#### Commit and Push on your branch
+#### Commit and push on your branch
 
 ```bash
 git add <files>

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,4 +1,4 @@
-# Decathlon/vitamin-web contributors (sorted alphabetically)
+# Decathlon/vitamin-ios contributors (sorted alphabetically)
 
 - **[Amaury David](https://github.com/amaurydavid)**
 


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
The goal is to align our GitHub different configuration files between `vitamin-(web|android|ios)` stacks.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
This PR is there to enhance the contributor experience and facilitate onboarding for developers.

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Don't request your main!
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks.
- [x] Check PR name, it must follow the https://www.conventionalcommits.org pattern.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
