### PR TITLE
fix: components and showcase for dark mode

### DIFF
--- a/Showcase/Application/Components/Button/ButtonsViewController.swift
+++ b/Showcase/Application/Components/Button/ButtonsViewController.swift
@@ -45,6 +45,11 @@ extension ButtonsViewController {
         cell.update(for: styles[indexPath.row], isEnabled: showEnabledState)
         return cell
     }
+
+    override func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        52
+    }
+
     override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
         makeSwitchButtonStateView()
     }

--- a/Showcase/Application/Components/Button/ButtonsViewController.swift
+++ b/Showcase/Application/Components/Button/ButtonsViewController.swift
@@ -7,8 +7,10 @@ import UIKit
 import Vitamin
 
 final class ButtonsViewController: UITableViewController {
+    private var showEnabledState = true
+
     convenience init() {
-        self.init(style: .grouped)
+        self.init(style: .plain)
     }
 
     override func viewDidLoad() {
@@ -40,7 +42,40 @@ extension ButtonsViewController {
                     return cell
                 }
         cell.selectionStyle = .none
-        cell.update(for: styles[indexPath.row])
+        cell.update(for: styles[indexPath.row], isEnabled: showEnabledState)
         return cell
+    }
+    override func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        makeSwitchButtonStateView()
+    }
+}
+
+extension ButtonsViewController {
+    private func makeSwitchButtonStateView() -> UIView {
+        let contentView = UIView()
+        contentView.backgroundColor = VitaminColor.Core.Background.secondary
+
+        let textLabel = UILabel()
+        textLabel.text = "Show enabled state"
+        contentView.addSubview(textLabel)
+        textLabel.translatesAutoresizingMaskIntoConstraints = false
+        textLabel.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16).isActive = true
+        textLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: 0).isActive = true
+
+        let stateSwitch = UISwitch()
+        stateSwitch.addTarget(self, action: #selector(switchValueChanged), for: .valueChanged)
+        stateSwitch.isOn = showEnabledState
+        contentView.addSubview(stateSwitch)
+        stateSwitch.translatesAutoresizingMaskIntoConstraints = false
+        stateSwitch.leadingAnchor.constraint(equalTo: textLabel.trailingAnchor, constant: 16).isActive = true
+        stateSwitch.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16).isActive = true
+        stateSwitch.centerYAnchor.constraint(equalTo: contentView.centerYAnchor, constant: 0).isActive = true
+
+        return contentView
+    }
+
+    @objc private func switchValueChanged(_ sender: UISwitch) {
+        showEnabledState = sender.isOn
+        tableView.reloadData()
     }
 }

--- a/Showcase/Application/Components/Button/Cell/ButtonTableViewCell.swift
+++ b/Showcase/Application/Components/Button/Cell/ButtonTableViewCell.swift
@@ -36,8 +36,8 @@ final class ButtonTableViewCell: UITableViewCell {
         ibLargeButton.isEnabled = isEnabled
 
         contentView.backgroundColor = style.needsDarkBackground ?
-        VitaminColor.Theme.Core.Dark.backgroundPrimary :
-        VitaminColor.Theme.Core.Light.backgroundPrimary
+        VitaminColor.Core.Background.brandPrimary :
+        VitaminColor.Core.Background.primary
     }
 }
 

--- a/Showcase/Application/Components/Button/Cell/ButtonTableViewCell.swift
+++ b/Showcase/Application/Components/Button/Cell/ButtonTableViewCell.swift
@@ -20,14 +20,7 @@ final class ButtonTableViewCell: UITableViewCell {
         }
     }
 
-    @IBOutlet weak var ibSwitch: UISwitch!
-
-    @IBAction func didUpdateSwitchValue() {
-        ibMediumButton.isEnabled = ibSwitch.isOn
-        ibLargeButton.isEnabled = ibSwitch.isOn
-    }
-
-    func update(for style: VitaminButton.Style) {
+    func update(for style: VitaminButton.Style, isEnabled: Bool) {
         ibMediumButton.style = style
         ibLargeButton.style = style
 
@@ -38,6 +31,9 @@ final class ButtonTableViewCell: UITableViewCell {
             Vitamix.Line.System.arrowRightS.image,
             for: .normal,
             renderingMode: .alwaysTemplate)
+
+        ibMediumButton.isEnabled = isEnabled
+        ibLargeButton.isEnabled = isEnabled
 
         contentView.backgroundColor = style.needsDarkBackground ?
         VitaminColor.Theme.Core.Dark.backgroundPrimary :

--- a/Showcase/Application/Components/Button/Cell/ButtonTableViewCell.xib
+++ b/Showcase/Application/Components/Button/Cell/ButtonTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19455" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19454"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -19,42 +19,33 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="bnP-7f-vgf">
-                        <rect key="frame" x="20" y="20" width="317" height="244"/>
+                        <rect key="frame" x="20" y="20" width="374" height="244"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="riL-iH-YB3" customClass="VitaminButton" customModule="Vitamin">
-                                <rect key="frame" x="131.5" y="0.0" width="54" height="118"/>
+                                <rect key="frame" x="160" y="0.0" width="54" height="118"/>
                                 <state key="normal" title="Button">
                                     <color key="titleColor" systemColor="labelColor"/>
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wmJ-0t-lzC" customClass="VitaminButton" customModule="Vitamin">
-                                <rect key="frame" x="131.5" y="126" width="54" height="118"/>
+                                <rect key="frame" x="160" y="126" width="54" height="118"/>
                                 <state key="normal" title="Button">
                                     <color key="titleColor" systemColor="labelColor"/>
                                 </state>
                             </button>
                         </subviews>
                     </stackView>
-                    <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="p2J-sn-oDT">
-                        <rect key="frame" x="345" y="126.5" width="51" height="31"/>
-                        <connections>
-                            <action selector="didUpdateSwitchValue" destination="OKD-QQ-uyu" eventType="valueChanged" id="AVz-1n-0Js"/>
-                        </connections>
-                    </switch>
                 </subviews>
                 <constraints>
                     <constraint firstItem="bnP-7f-vgf" firstAttribute="leading" secondItem="5Jr-hU-tma" secondAttribute="leading" constant="20" symbolic="YES" id="6CV-82-Xnh"/>
-                    <constraint firstAttribute="trailing" secondItem="p2J-sn-oDT" secondAttribute="trailing" constant="20" symbolic="YES" id="9O6-Pi-VwG"/>
                     <constraint firstItem="bnP-7f-vgf" firstAttribute="top" secondItem="5Jr-hU-tma" secondAttribute="top" constant="20" symbolic="YES" id="TLK-f1-V33"/>
-                    <constraint firstItem="p2J-sn-oDT" firstAttribute="leading" secondItem="bnP-7f-vgf" secondAttribute="trailing" constant="8" symbolic="YES" id="bNj-JM-f9N"/>
+                    <constraint firstAttribute="trailing" secondItem="bnP-7f-vgf" secondAttribute="trailing" constant="20" symbolic="YES" id="hRn-Z5-i7r"/>
                     <constraint firstAttribute="bottom" secondItem="bnP-7f-vgf" secondAttribute="bottom" constant="20" symbolic="YES" id="jeB-nB-arD"/>
-                    <constraint firstItem="p2J-sn-oDT" firstAttribute="centerY" secondItem="5Jr-hU-tma" secondAttribute="centerY" id="yAX-5t-3kR"/>
                 </constraints>
             </tableViewCellContentView>
             <connections>
                 <outlet property="ibLargeButton" destination="wmJ-0t-lzC" id="iBv-E2-5Eg"/>
                 <outlet property="ibMediumButton" destination="riL-iH-YB3" id="zc1-UU-F2l"/>
-                <outlet property="ibSwitch" destination="p2J-sn-oDT" id="pIQ-Fi-x3L"/>
             </connections>
             <point key="canvasLocation" x="-123" y="1"/>
         </tableViewCell>

--- a/Showcase/Application/Components/Switch/SwitchViewController.swift
+++ b/Showcase/Application/Components/Switch/SwitchViewController.swift
@@ -42,6 +42,10 @@ extension SwitchViewController {
         cell.selectionStyle = .none
         return cell
     }
+
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        44
+    }
 }
 
 private struct VitaminSwitchDemoConfig {

--- a/Showcase/Application/Foundations/Colors/ColorsViewController.swift
+++ b/Showcase/Application/Foundations/Colors/ColorsViewController.swift
@@ -39,6 +39,10 @@ extension ColorsViewController {
         cell.setColor(item.name, color: item.color)
         return cell
     }
+
+    override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        76
+    }
 }
 
 extension ColorsViewController {

--- a/Showcase/Application/Foundations/Icons/Cell/IconCollectionViewCell.swift
+++ b/Showcase/Application/Foundations/Icons/Cell/IconCollectionViewCell.swift
@@ -9,8 +9,9 @@ final class IconCollectionViewCell: UICollectionViewCell {
     @IBOutlet weak var ibImageView: UIImageView!
     @IBOutlet weak var ibLabel: UILabel!
 
-    func setImage(_ image: UIImage, name: String) {
-        ibImageView.image = image
+    func setImage(_ image: UIImage, name: String, color: UIColor) {
+        ibImageView.image = image.withRenderingMode(.alwaysTemplate)
+        ibImageView.tintColor = color
         ibLabel.text = name
     }
 }

--- a/Showcase/Application/Foundations/Icons/IconsViewController.swift
+++ b/Showcase/Application/Foundations/Icons/IconsViewController.swift
@@ -53,6 +53,14 @@ extension IconsViewController: UICollectionViewDelegateFlowLayout {
     ) -> CGSize {
         CGSize(width: view.frame.width / 5, height: 80)
     }
+
+    func collectionView(
+        _ collectionView: UICollectionView,
+        layout collectionViewLayout: UICollectionViewLayout,
+        insetForSectionAt section: Int
+    ) -> UIEdgeInsets {
+        UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
+    }
 }
 
 extension IconsViewController {

--- a/Showcase/Application/Foundations/Icons/IconsViewController.swift
+++ b/Showcase/Application/Foundations/Icons/IconsViewController.swift
@@ -8,8 +8,7 @@ import UIKit
 import Vitamin
 
 final class IconsViewController: UICollectionViewController {
-    private static let headerBackgroundColor = UIColor(red: 242 / 255, green: 242 / 255, blue: 247 / 255, alpha: 1)
-    private static let headerTextColor = UIColor(red: 137 / 255, green: 137 / 255, blue: 142 / 255, alpha: 1)
+    private static let cellTextColor = VitaminColor.Core.Content.primary
 
     private lazy var sections: [IconSection] = makeSections()
 
@@ -25,7 +24,7 @@ final class IconsViewController: UICollectionViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = Self.headerBackgroundColor
+        view.backgroundColor = VitaminColor.Core.Background.primary
 
         navigationItem.title = "Icons"
         collectionView.register(
@@ -41,20 +40,6 @@ final class IconsViewController: UICollectionViewController {
 
         if let flow = self.collectionView.collectionViewLayout as? UICollectionViewFlowLayout {
             flow.headerReferenceSize = CGSize(width: view.frame.width, height: 55)
-        }
-
-        if #available(iOS 15, *) {
-            let appearance = UINavigationBarAppearance()
-            appearance.configureWithTransparentBackground()
-            appearance.backgroundColor = Self.headerBackgroundColor
-            navigationController?.navigationBar
-                .standardAppearance = appearance
-            navigationController?.navigationBar
-                .scrollEdgeAppearance = navigationController?.navigationBar.standardAppearance
-        } else {
-            navigationController?.navigationBar.barTintColor = Self.headerBackgroundColor
-            navigationController?.navigationBar.isTranslucent = false
-            navigationController?.navigationBar.barStyle = .blackTranslucent
         }
     }
 }
@@ -93,7 +78,8 @@ extension IconsViewController {
                     return cell
                 }
         let iconItem = sections[indexPath.section].items[indexPath.row]
-        cell.setImage(iconItem.image, name: iconItem.shortName)
+        cell.setImage(iconItem.image, name: iconItem.shortName, color: Self.cellTextColor)
+        cell.ibLabel.textColor = Self.cellTextColor
         return cell
     }
 
@@ -110,7 +96,7 @@ extension IconsViewController {
             withReuseIdentifier: "header",
             for: indexPath)
 
-        headerView.backgroundColor = Self.headerBackgroundColor
+        headerView.backgroundColor = VitaminColor.Core.Background.secondary
         if headerView.subviews.isEmpty {
             headerView.addSubview(
                 UILabel(
@@ -122,10 +108,10 @@ extension IconsViewController {
         }
 
         if let headerLabel = headerView.subviews[0] as? UILabel {
-            headerLabel.backgroundColor = Self.headerBackgroundColor
+            headerLabel.backgroundColor = .clear
             headerLabel.text = self.sections[indexPath.section].name.uppercased()
             headerLabel.font = UIFont.systemFont(ofSize: 13)
-            headerLabel.textColor = Self.headerTextColor
+            headerLabel.textColor = VitaminColor.Core.Content.tertiary
             headerLabel.textAlignment = .left
         }
 

--- a/Sources/Vitamin/Components/Button/VitaminButton.swift
+++ b/Sources/Vitamin/Components/Button/VitaminButton.swift
@@ -58,6 +58,11 @@ public class VitaminButton: UIButton {
         applyNewTextStyle()
     }
 
+    public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        applyNewStyle()
+    }
+
     public override var intrinsicContentSize: CGSize {
         let baseSize = super.intrinsicContentSize
         return CGSize(

--- a/Sources/Vitamin/Foundations/Typography/TextStyles.swift
+++ b/Sources/Vitamin/Foundations/Typography/TextStyles.swift
@@ -72,7 +72,7 @@ extension VitaminTextStyle {
         }
         let scaledFont = makeScaledFont(for: font, textStyle: textStyle)
         return [
-            .foregroundColor: VitaminColor.Base.black.color,
+            .foregroundColor: VitaminColor.Core.Content.primary,
             .font: scaledFont,
             .paragraphStyle: paragraphStyle,
             .baselineOffset: baseLineOffset


### PR DESCRIPTION
## Changes description

After checking the showcase, I've seen that there is some issues with dark mode.
Some issues are in on the showcase and others in the components.

### 🧩 Components

#### 💬 TextStyle

- Use dark mode compatible color for default text color (it's the same color but dark mode compatible).

#### 🕹 Button

- Fix background color update when switching from light to dark (or inversely).

### 📲 In showcase

#### 🎨 Colors

- Fix autolayout issues.

#### 🖼 Icons

- Use dark mode compatible colors.

#### 🕹 Button

- Fix autolayout issues.
- Set a global switch for state enable/disable.
- Use dark mode compatible colors.

#### 🎚 Switch

- Fix autolayout issues.

## Context

This change is required to do a better showcase and fix some issues with components.

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] I have tested on an iPad device/simulator.

## Does this introduce a breaking change?

- No, but it could be an issue if you use the default `TextStyle` font color in dark mode. It'll be white instead of black. To fix it just set the white color in color argument.

## Screenshots

#### iPhone

| Before | After |
| ----- | ----- |
| ![Simulator Screen Shot - iPhone 12 - 2022-01-17 at 19 44 49](https://user-images.githubusercontent.com/87971589/149823584-594e4a99-e63a-481c-8ea0-f74d1597857b.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-17 at 19 32 07](https://user-images.githubusercontent.com/87971589/149823615-ae3e4c32-ac6b-4770-89b4-6f3bdc372921.png) |
| ![Simulator Screen Shot - iPhone 12 - 2022-01-17 at 19 45 03](https://user-images.githubusercontent.com/87971589/149823793-8858de9c-f0bf-4fb7-8176-d28b538b5e17.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-17 at 19 32 14](https://user-images.githubusercontent.com/87971589/149823804-93b1ffd3-dec3-453e-af15-c574e2ce3584.png) |
| ![Simulator Screen Shot - iPhone 12 - 2022-01-17 at 19 53 16](https://user-images.githubusercontent.com/87971589/149824110-7be06f7a-ee98-429d-86c7-c539c1c5ff52.png) | ![Simulator Screen Shot - iPhone 12 - 2022-01-17 at 19 53 59](https://user-images.githubusercontent.com/87971589/149824156-362ea95a-46da-464d-abd6-5da62e96c7b5.png) |




