### PR TITLE
chore(showcase): build showcase - deploy on bitrise - slack

### DIFF
--- a/.github/workflows/PullRequestLabeledForDesignReview.yml
+++ b/.github/workflows/PullRequestLabeledForDesignReview.yml
@@ -1,0 +1,33 @@
+name: Check for Bitrise Label
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+
+jobs:
+  buildshowcase:
+    name: Trigger Build with Label
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get the pull request number
+        id: pr_number
+        run: |
+          echo ::set-output name=number::$(echo "$GITHUB_REF" | awk -F / '{print $3}')
+      - name: Send mobile build on bitrise
+        if: contains(github.event.pull_request.labels.*.name, 'Ready for Design Review')
+        run: |
+          curl https://app.bitrise.io/app/${{ secrets.BITRISE_APP_ID }}/build/start.json --data '{
+            "hook_info":{
+              "type":"bitrise",
+              "build_trigger_token":"${{ secrets.BITRISE_BUILD_TRIGGER }}"
+            },
+            "build_params":{
+              "branch":"${{ github.head_ref }}",
+              "branch_dest": "${{ github.event.pull_request.base.ref }}",
+              "workflow_id":"pull-request",
+              "commit_hash":"${{ github.event.pull_request.head.sha }}",
+              "pull_request_id": ${{ steps.pr_number.outputs.number }}
+            },
+            "triggered_by":"curl"
+          }'

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /Packages
 xcuserdata/
 DerivedData
+.bitrise*

--- a/Showcase/Vitamin Showcase.xcodeproj/project.pbxproj
+++ b/Showcase/Vitamin Showcase.xcodeproj/project.pbxproj
@@ -590,8 +590,9 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
-				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = TWLCQ9R2FN;
+				CODE_SIGN_IDENTITY = "iPhone Distribution: FONDATION D'ENTREPRISE OXYLANE ART";
+				CODE_SIGN_STYLE = Manual;
+				DEVELOPMENT_TEAM = EZELTPWNWS;
 				INFOPLIST_FILE = "Supporting Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -599,6 +600,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.decathlon.vitamin.showcase;
 				PRODUCT_NAME = Showcase;
+				PROVISIONING_PROFILE_SPECIFIER = "Vitamin Showcase - Bitrise - inHouse";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -1,13 +1,13 @@
 ---
 format_version: '11'
-default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
+default_step_lib_source: 'https://github.com/bitrise-io/bitrise-steplib.git'
 project_type: ios
 trigger_map:
 - push_branch: main
   workflow: primary
-- pull_request_source_branch: "*"
+- pull_request_source_branch: '*'
   workflow: primary
-- tag: "*"
+- tag: '*'
   workflow: deploy
 workflows:
   deploy:


### PR DESCRIPTION
## Changes description
Add a Github action to launch a build of the showcase when the PR is considered as OK on a technical point of view, thus ready for functional review by designers.

NOTE : the build is not launched on the Decathlon Public Bitrise account, thus, the workflow is not stored in the bitrise.yml file of the repo

## Context
This PR aims to provide a showcase app on each PR to ease the design review.
The showcase will be built only when :
- the PR is tagged with the 'Ready for Design Review' label
- the PR is updated (new commit, change base branch,...) since it is already labeled with 'Ready for Design Review'
The build will be made available on the private channel #vitamin-ios-functional-reveiws of the Decathlon Design System slack.
It aims to handle the #27 issue : resolves #27

## Checklist
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.

## Does this introduce a breaking change?
- No

## Screenshots

Slack Notification on private channel of Decathlon Design System slack:
<img width="408" alt="Capture d’écran 2022-02-01 à 12 03 54" src="https://user-images.githubusercontent.com/43171132/151957505-0dbf22fa-f2b8-4495-a58c-40d29c1955dd.png">


## Other information
This PR only handles the build of 'snapshot' showcase app on PR.
The build of "release" showcase app will be the topic of another PR.
