### PR TITLE
refactor: update TextStyle component to prepare next components

### DIFF
--- a/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.swift
+++ b/Showcase/Application/Foundations/Shadows/Cell/ShadowTableViewCell.swift
@@ -15,7 +15,8 @@ public class ShadowTableViewCell: UITableViewCell {
         exampleLabel.backgroundColor = VitaminColor.Core.Background.brandPrimary
         exampleLabel.dropShadow(shadowType: shadowType)
 
-        exampleLabel.attributedText = "This is a test label \nwith a \(shadowType.rawValue) shadow type".styled(as: .callout)
+        exampleLabel.attributedText = "This is a test label \nwith a \(shadowType.rawValue) shadow type"
+            .styled(as: .callout)
         exampleLabel.textAlignment = .center
     }
 }

--- a/Sources/Vitamin/Foundations/Typography/TextStyles.swift
+++ b/Sources/Vitamin/Foundations/Typography/TextStyles.swift
@@ -5,81 +5,156 @@
 
 import UIKit
 
-/// - Note: The VitaminTextStyle enumeration is of type String in order to be able to initialize a VitaminTextStyle from a String. For example to use an IBInspectable on a UILabel to automatically style it from storyboard.
-public enum VitaminTextStyle: String {
-    /// RobotoCondensed boldItalic 42pt on iOS
-    case display
-    case largeTitle1
-    case largeTitle2
-    case title1
-    case title2
-    case title3
-    case headline
-    case body
-    case callout
-    case subhead
-    case footnote
-    case caption1
-    case caption2
-    case button
+public struct VitaminTextStyle {
+    public let size: CGFloat
+    public let lineHeight: CGFloat
+    private let fontType: VitaminFontConvertible
+    private let textStyle: UIFont.TextStyle
+    public let rawValue: String
+
+    public static let display = VitaminTextStyle(size: 42,
+                                                 lineHeight: 44,
+                                                 fontType: VitaminFontFamily.RobotoCondensed.boldItalic,
+                                                 textStyle: .largeTitleCompatibility,
+                                                 rawValue: "display")
+    public static let largeTitle1 = VitaminTextStyle(size: 40,
+                                                     lineHeight: 44,
+                                                     fontType: VitaminFontFamily.Roboto.bold,
+                                                     textStyle: .largeTitleCompatibility,
+                                                     rawValue: "largeTitle1")
+    public static let largeTitle2 = VitaminTextStyle(size: 36,
+                                                     lineHeight: 40,
+                                                     fontType: VitaminFontFamily.Roboto.bold,
+                                                     textStyle: .largeTitleCompatibility,
+                                                     rawValue: "largeTitle2")
+    public static let title1 = VitaminTextStyle(size: 28,
+                                                lineHeight: 32,
+                                                fontType: VitaminFontFamily.Roboto.bold,
+                                                textStyle: .title1,
+                                                rawValue: "title1")
+    public static let title2 = VitaminTextStyle(size: 24,
+                                                lineHeight: 28,
+                                                fontType: VitaminFontFamily.Roboto.bold,
+                                                textStyle: .title2,
+                                                rawValue: "title2")
+    public static let title3 = VitaminTextStyle(size: 20,
+                                                lineHeight: 24,
+                                                fontType: VitaminFontFamily.Roboto.bold,
+                                                textStyle: .title3,
+                                                rawValue: "title3")
+    public static let headline = VitaminTextStyle(size: 16,
+                                                  lineHeight: 24,
+                                                  fontType: VitaminFontFamily.Roboto.bold,
+                                                  textStyle: .headline,
+                                                  rawValue: "headline")
+    public static let body = VitaminTextStyle(size: 17,
+                                              lineHeight: 28,
+                                              fontType: VitaminFontFamily.Roboto.regular,
+                                              textStyle: .body,
+                                              rawValue: "body")
+    public static let callout = VitaminTextStyle(size: 16,
+                                                 lineHeight: 24,
+                                                 fontType: VitaminFontFamily.Roboto.regular,
+                                                 textStyle: .callout,
+                                                 rawValue: "callout")
+    public static let subhead = VitaminTextStyle(size: 15,
+                                                 lineHeight: 20,
+                                                 fontType: VitaminFontFamily.Roboto.regular,
+                                                 textStyle: .subheadline,
+                                                 rawValue: "subhead")
+    public static let footnote = VitaminTextStyle(size: 14,
+                                                  lineHeight: 20,
+                                                  fontType: VitaminFontFamily.Roboto.regular,
+                                                  textStyle: .footnote,
+                                                  rawValue: "footnote")
+    public static let caption1 = VitaminTextStyle(size: 12,
+                                                  lineHeight: 16,
+                                                  fontType: VitaminFontFamily.Roboto.regular,
+                                                  textStyle: .caption1,
+                                                  rawValue: "caption1")
+    public static let caption2 = VitaminTextStyle(size: 11,
+                                                  lineHeight: 13,
+                                                  fontType: VitaminFontFamily.Roboto.regular,
+                                                  textStyle: .caption2,
+                                                  rawValue: "caption2")
+    public static let button = VitaminTextStyle(size: 16,
+                                                lineHeight: 16,
+                                                fontType: VitaminFontFamily.Roboto.bold,
+                                                textStyle: .body,
+                                                rawValue: "button")
 }
 
-extension VitaminTextStyle {
-    private func baseAttributes(
-        sizeProvider: SizeProvider,
-        font: VitaminFontConvertible,
-        lineHeight: SizeProvider
-    ) -> [NSAttributedString.Key: Any] {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.minimumLineHeight = lineHeight.size
-        paragraphStyle.maximumLineHeight = lineHeight.size
-        let font = font.font(size: sizeProvider.size)
+// MARK: - RawRepresentable
 
-        // Computing the baselineOffset needed to center the texte in its line height.
-        // The baselineOffset should be the quarter of the difference between size and lineheight.
-        let baseLineOffset = (lineHeight.size - sizeProvider.size) / 4
-
-        var textStyle: UIFont.TextStyle
-        switch self {
-        case .display:
-            textStyle = .largeTitleCompatibility
-        case .largeTitle1:
-            textStyle = .largeTitleCompatibility
-        case .largeTitle2:
-            textStyle = .largeTitleCompatibility
-        case .title1:
-            textStyle = .title1
-        case .title2:
-            textStyle = .title2
-        case .title3:
-            textStyle = .title2
-        case .headline:
-            textStyle = .headline
-        case .body:
-            textStyle = .body
-        case .callout:
-            textStyle = .callout
-        case .subhead:
-            textStyle = .subheadline
-        case .footnote:
-            textStyle = .footnote
-        case .caption1:
-            textStyle = .caption1
-        case .caption2:
-            textStyle = .caption2
-        case .button:
-            textStyle = .body
+/// - Note: The `VitaminTextStyle` use the `RawRepresentable` in order to be able.
+/// to initialize a `VitaminTextStyle` from a String.
+/// For example to use an `IBInspectable` on a `UILabel` to automatically set the style in the storyboard.
+extension VitaminTextStyle: RawRepresentable {
+    // swiftlint:disable:next cyclomatic_complexity
+    public init?(rawValue: String) {
+        switch rawValue {
+        case "display": self = .display
+        case "largeTitle1": self = .largeTitle1
+        case "largeTitle2": self = .largeTitle2
+        case "title1": self = .title1
+        case "title2": self = .title2
+        case "title3": self = .title3
+        case "headline": self = .headline
+        case "body": self = .body
+        case "callout": self = .callout
+        case "subhead": self = .subhead
+        case "footnote": self = .footnote
+        case "caption1": self = .caption1
+        case "caption2": self = .caption2
+        case "button": self = .button
+        default: return nil
         }
-        let scaledFont = makeScaledFont(for: font, textStyle: textStyle)
-        return [
-            .foregroundColor: VitaminColor.Core.Content.primary,
-            .font: scaledFont,
-            .paragraphStyle: paragraphStyle,
-            .baselineOffset: baseLineOffset
-        ]
+    }
+}
+
+// MARK: - Private methods
+
+extension VitaminTextStyle {
+    /// The paragraph style for the current style.
+    private func paragraphStyle(lineHeight: CGFloat) -> NSParagraphStyle {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.minimumLineHeight = lineHeight
+        paragraphStyle.maximumLineHeight = lineHeight
+        return paragraphStyle
     }
 
-    private func makeScaledFont(for font: UIFont, textStyle: UIFont.TextStyle) -> UIFont {
+    /// The baseline offset for the current style.
+    private func baselineOffset(lineHeight: CGFloat, size: CGFloat) -> CGFloat {
+        // Computing the baselineOffset needed to center the text in its line height.
+        // The baselineOffset should be the quarter of the difference between size and lineheight.
+        (lineHeight - size) / 4
+    }
+}
+
+// MARK: - TextStyle extension
+
+extension UIFont.TextStyle {
+    /// Return a large title `TextStyle` compatible with the current iOS version.
+    /// - Note: Return `.largeTitle` if iOS >= 11, otherwise `.title1`.
+    static var largeTitleCompatibility: UIFont.TextStyle {
+        if #available(iOS 11.0, *) {
+            return .largeTitle
+        } else {
+            return .title1
+        }
+    }
+}
+
+// MARK: - Public methods
+
+extension VitaminTextStyle {
+    /// The font with the size for the current style.
+    public var font: UIFont {
+        fontType.font(size: size)
+    }
+
+    /// The font with a scaled size adjusted with accessibility settings for the current style.
+    public var scaledFont: UIFont {
         if #available(iOS 11.0, *) {
             let metrics = UIFontMetrics(forTextStyle: textStyle)
             return metrics.scaledFont(for: font)
@@ -88,124 +163,46 @@ extension VitaminTextStyle {
         }
     }
 
+    /// The scaled line height with the provided font for the current style.
+    /// - Parameter font: The font for which we want the line height.
+    /// - Returns: The adjusted line height value.
+    public func scaledLineHeight(for font: UIFont) -> CGFloat {
+        (lineHeight * font.pointSize) / size
+    }
+
+    /// All attributes for the current style.
+    /// `.foregroundColor`: The text color.
+    /// `.font`: The font for the current style.
+    /// `.paragraphStyle`: The paragraph style for the current style.
+    /// `.baselineOffset`: The baselineOffset for the current style.
     public var attributes: [NSAttributedString.Key: Any] {
-        switch self {
-        case .display:
-            return baseAttributes(
-                sizeProvider: 42,
-                font: VitaminFontFamily.RobotoCondensed.boldItalic,
-                lineHeight: 44
-            )
-        case .largeTitle1:
-            return baseAttributes(
-                sizeProvider: 40,
-                font: VitaminFontFamily.Roboto.bold,
-                lineHeight: 44
-            )
-        case .largeTitle2:
-            return baseAttributes(
-                sizeProvider: 36,
-                font: VitaminFontFamily.Roboto.bold,
-                lineHeight: 40
-            )
-        case .title1:
-            return baseAttributes(
-                sizeProvider: 28,
-                font: VitaminFontFamily.Roboto.bold,
-                lineHeight: 32
-            )
-
-        case .title2:
-            return baseAttributes(
-                sizeProvider: 24,
-                font: VitaminFontFamily.Roboto.bold,
-                lineHeight: 28
-            )
-
-        case .title3:
-            return baseAttributes(
-                sizeProvider: 20,
-                font: VitaminFontFamily.Roboto.bold,
-                lineHeight: 24
-            )
-
-        case .headline:
-            return baseAttributes(
-                sizeProvider: 16,
-                font: VitaminFontFamily.Roboto.bold,
-                lineHeight: 24
-            )
-
-        case .body:
-            return baseAttributes(
-                sizeProvider: 17,
-                font: VitaminFontFamily.Roboto.regular,
-                lineHeight: 28
-            )
-
-        case .callout:
-            return baseAttributes(
-                sizeProvider: 16,
-                font: VitaminFontFamily.Roboto.regular,
-                lineHeight: 24
-            )
-
-        case .subhead:
-            return baseAttributes(
-                sizeProvider: 15,
-                font: VitaminFontFamily.Roboto.regular,
-                lineHeight: 20
-            )
-
-        case .footnote:
-            return baseAttributes(
-                sizeProvider: 14,
-                font: VitaminFontFamily.Roboto.regular,
-                lineHeight: 20
-            )
-
-        case .caption1:
-            return baseAttributes(
-                sizeProvider: 12,
-                font: VitaminFontFamily.Roboto.regular,
-                lineHeight: 16
-            )
-
-        case .caption2:
-            return baseAttributes(
-                sizeProvider: 11,
-                font: VitaminFontFamily.Roboto.regular,
-                lineHeight: 13
-            )
-
-        case .button:
-            return baseAttributes(
-                sizeProvider: 16,
-                font: VitaminFontFamily.Roboto.bold,
-                lineHeight: 16
-            )
-        }
+        let adjustedFont = scaledFont
+        let adjustedSize = adjustedFont.pointSize
+        let adjustedLineHeight = scaledLineHeight(for: adjustedFont)
+        let paragraphStyle = paragraphStyle(lineHeight: adjustedLineHeight)
+        let baselineOffset = baselineOffset(lineHeight: adjustedLineHeight, size: adjustedSize)
+        return [
+            .foregroundColor: VitaminColor.Core.Content.primary,
+            .font: adjustedFont,
+            .paragraphStyle: paragraphStyle,
+            .baselineOffset: baselineOffset
+        ]
     }
 }
+
+// MARK: - Public String extension
 
 extension String {
-    public func styled(as textStyle: VitaminTextStyle) -> NSAttributedString {
-        NSAttributedString(string: self, attributes: textStyle.attributes)
-    }
-
-    public func styled(as textStyle: VitaminTextStyle, with color: UIColor) -> NSAttributedString {
+    /// Get the `NSAttributedString` to render provided style.
+    /// - Parameters:
+    ///   - textStyle: The style that we want to apply.
+    ///   - textColor: The color for the text. Optional. Default: `VitaminColor.Core.Content.primary`.
+    /// - Returns: A `NSAttributedString` with all attributes.
+    public func styled(as textStyle: VitaminTextStyle, with textColor: UIColor? = nil) -> NSAttributedString {
         var attributes = textStyle.attributes
-        attributes[.foregroundColor] = color
-        return NSAttributedString(string: self, attributes: attributes)
-    }
-}
-
-extension UIFont.TextStyle {
-    static var largeTitleCompatibility: UIFont.TextStyle {
-        if #available(iOS 11.0, *) {
-            return .largeTitle
-        } else {
-            return .title1
+        if let color = textColor {
+            attributes[.foregroundColor] = color
         }
+        return NSAttributedString(string: self, attributes: attributes)
     }
 }


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Refacto `TextStyle` to expose more easily the needed informations like font or size. This is needed to start `SwiftUI` version of the `TextStyle` to avoid duplications.  
This PR also fix a line height issue with large accessibility font size.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
In some case when need to access to some informations like `font` or `size` and it was currently not easy.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Screenshots

#### iPhone
<!--- Put your iPhone screenshots here. -->

No changes on the UI, big changes in code.

| Before | After |
| ------ | ------ |
| ![Before_1](https://user-images.githubusercontent.com/87971589/151042768-30dba418-00e2-4a3b-9221-4ce17a682a1f.png) | ![After_1](https://user-images.githubusercontent.com/87971589/151043022-b3177813-1057-4cb4-8325-8763ce4f8f90.png)|
| ![Before_2](https://user-images.githubusercontent.com/87971589/151042765-877a9eb1-1a60-4706-a32a-b5f6a25bcbdb.png) | ![After_2](https://user-images.githubusercontent.com/87971589/151043044-f74c1f6a-37dd-43a7-a514-851f6b4b43f6.png) |
| ![Before_3](https://user-images.githubusercontent.com/87971589/151042754-47503504-006d-4267-a574-ff918be42542.png) | ![After_3](https://user-images.githubusercontent.com/87971589/151043041-11bc0426-0e96-4c04-9045-a4ffe9df47dd.png) |
| ![Issue_before](https://user-images.githubusercontent.com/87971589/151045532-bb878073-d9b5-468b-aff2-a6932efdf6cc.png) | ![Issue_after](https://user-images.githubusercontent.com/87971589/151045574-06d12635-c510-4d7a-9f0e-f248b7105699.png) |


## 🧑‍💻 Developer notes

- Switch from `enum` to `struct` to reduce the number of switch case to do.