### PR TITLE
refactor: replace toggle color for dark mode #29

### DIFF
--- a/Sources/Vitamin/Components/Switch/VitaminSwitch.swift
+++ b/Sources/Vitamin/Components/Switch/VitaminSwitch.swift
@@ -43,6 +43,6 @@ public class VitaminSwitch: UISwitch {
         self.tintColor = VitaminColor.Core.Content.inactive
         self.backgroundColor = VitaminColor.Core.Content.inactive
         self.onTintColor = VitaminColor.Core.Content.active
-        self.thumbTintColor = VitaminColor.Core.Content.primaryReversed
+        self.thumbTintColor = VitaminColor.Base.white.color
     }
 }


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->

Findings:

On vitamin, toggle button switch from white to dark depending on the theme selected
Toggle button on iOS dark mode is still white (there is no color switch).

Proposal

In order to respect the platform as much as possible, I propose to replace the semantic coloring by a color base

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->

- [x] Fix #29 

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Screenshots

![dark_mode_switch](https://user-images.githubusercontent.com/87971589/151047876-7c4b1ef3-93a6-4c40-a964-8f1adf00e535.png)
