### PR TITLE
fix: force button configuration to default

### DIFF
--- a/Sources/Vitamin/Components/Button/VitaminButton.swift
+++ b/Sources/Vitamin/Components/Button/VitaminButton.swift
@@ -111,6 +111,9 @@ public class VitaminButton: UIButton {
 
 extension VitaminButton {
     private func applyNewStyle() {
+        if #available(iOS 15, *) {
+            self.configuration = nil
+        }
         let states: [UIControl.State] = [.normal, .disabled, .highlighted]
         states.forEach {
             setBackgroundImage(UIImage.imageWithColor(style.backgroundColor(for: $0)), for: $0)


### PR DESCRIPTION
## Changes description
For iOS15+, force button configuration to default (it is by default to Plain when creating a Button in Storyboard or xib)

## Context
fixes #62 

## Checklist
<!--- Feel free to add other steps if needed. -->

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [ ] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [ ] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [ ] I have tested on an iPhone device/simulator.
- [ ] I have tested on an iPad device/simulator.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Screenshots
#### iPhone
N/A

#### iPad
N/A
