### PR TITLE
feat(button): add icon alone UIKit VitaminButton type, and refactor icon management

### DIFF
--- a/Showcase/Application/UIKit/Components/Button/Cell/ButtonTableViewCell.swift
+++ b/Showcase/Application/UIKit/Components/Button/Cell/ButtonTableViewCell.swift
@@ -39,11 +39,27 @@ final class ButtonTableViewCell: UITableViewCell {
 
         mediumButton.setTitle("\(style)", for: .normal)
         largeButton.setTitle("\(style)", for: .normal)
-        
-        mediumButton.setIconType(.trailing(image: Vitamix.Line.Logos.apple.image, renderingMode: .alwaysTemplate), for: .normal)
-        largeButton.setIconType(.leading(image: Vitamix.Line.System.arrowRightS.image, renderingMode: .alwaysTemplate), for: .normal)
-        mediumIconAloneButton.setIconType(.alone(image: Vitamix.Line.Logos.apple.image, renderingMode: .alwaysTemplate), for: .normal)
-        largeIconAloneButton.setIconType(.alone(image: Vitamix.Line.System.arrowRightS.image, renderingMode: .alwaysTemplate), for: .normal)
+
+        mediumButton.setIconType(
+            .trailing(
+                image: Vitamix.Line.Logos.apple.image,
+                renderingMode: .alwaysTemplate),
+            for: .normal)
+        largeButton.setIconType(
+            .leading(
+                image: Vitamix.Line.System.arrowRightS.image,
+                renderingMode: .alwaysTemplate),
+            for: .normal)
+        mediumIconAloneButton.setIconType(
+            .alone(
+                image: Vitamix.Line.Logos.apple.image,
+                renderingMode: .alwaysTemplate),
+            for: .normal)
+        largeIconAloneButton.setIconType(
+            .alone(
+                image: Vitamix.Line.System.arrowRightS.image,
+                renderingMode: .alwaysTemplate),
+            for: .normal)
 
         mediumButton.isEnabled = isEnabled
         largeButton.isEnabled = isEnabled

--- a/Showcase/Application/UIKit/Components/Button/Cell/ButtonTableViewCell.swift
+++ b/Showcase/Application/UIKit/Components/Button/Cell/ButtonTableViewCell.swift
@@ -19,21 +19,36 @@ final class ButtonTableViewCell: UITableViewCell {
             largeButton.size = .large
         }
     }
+    @IBOutlet weak var mediumIconAloneButton: VitaminButton! {
+        didSet {
+            mediumIconAloneButton.size = .medium
+        }
+    }
+
+    @IBOutlet weak var largeIconAloneButton: VitaminButton! {
+        didSet {
+            largeIconAloneButton.size = .large
+        }
+    }
 
     func update(for style: VitaminButton.Style, isEnabled: Bool) {
         mediumButton.style = style
         largeButton.style = style
+        mediumIconAloneButton.style = style
+        largeIconAloneButton.style = style
 
         mediumButton.setTitle("\(style)", for: .normal)
         largeButton.setTitle("\(style)", for: .normal)
-        mediumButton.setLeadingImage(Vitamix.Line.Logos.apple.image, for: .normal, renderingMode: .alwaysTemplate)
-        largeButton.setTrailingImage(
-            Vitamix.Line.System.arrowRightS.image,
-            for: .normal,
-            renderingMode: .alwaysTemplate)
+        
+        mediumButton.setIconType(.trailing(image: Vitamix.Line.Logos.apple.image, renderingMode: .alwaysTemplate), for: .normal)
+        largeButton.setIconType(.leading(image: Vitamix.Line.System.arrowRightS.image, renderingMode: .alwaysTemplate), for: .normal)
+        mediumIconAloneButton.setIconType(.alone(image: Vitamix.Line.Logos.apple.image, renderingMode: .alwaysTemplate), for: .normal)
+        largeIconAloneButton.setIconType(.alone(image: Vitamix.Line.System.arrowRightS.image, renderingMode: .alwaysTemplate), for: .normal)
 
         mediumButton.isEnabled = isEnabled
         largeButton.isEnabled = isEnabled
+        mediumIconAloneButton.isEnabled = isEnabled
+        largeIconAloneButton.isEnabled = isEnabled
 
         contentView.backgroundColor = style.needsReversedBackground ?
         VitaminColor.Core.Background.brandPrimary :

--- a/Showcase/Application/UIKit/Components/Button/Cell/ButtonTableViewCell.xib
+++ b/Showcase/Application/UIKit/Components/Button/Cell/ButtonTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Stack View standard spacing" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,21 +18,41 @@
                 <rect key="frame" x="0.0" y="0.0" width="414" height="284"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="bnP-7f-vgf">
+                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacingType="standard" translatesAutoresizingMaskIntoConstraints="NO" id="bnP-7f-vgf">
                         <rect key="frame" x="20" y="20" width="374" height="244"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="riL-iH-YB3" customClass="VitaminButton" customModule="Vitamin">
-                                <rect key="frame" x="160" y="0.0" width="54" height="118"/>
+                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="riL-iH-YB3" customClass="VitaminButton" customModule="Vitamin">
+                                <rect key="frame" x="160" y="0.0" width="54" height="34"/>
                                 <state key="normal" title="Button">
                                     <color key="titleColor" systemColor="labelColor"/>
                                 </state>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wmJ-0t-lzC" customClass="VitaminButton" customModule="Vitamin">
-                                <rect key="frame" x="160" y="126" width="54" height="118"/>
+                                <rect key="frame" x="160" y="42" width="54" height="34"/>
                                 <state key="normal" title="Button">
                                     <color key="titleColor" systemColor="labelColor"/>
                                 </state>
                             </button>
+                            <stackView opaque="NO" contentMode="center" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="MUK-Sd-UPa">
+                                <rect key="frame" x="118" y="84" width="138" height="160"/>
+                                <subviews>
+                                    <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" adjustsImageWhenHighlighted="NO" adjustsImageWhenDisabled="NO" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="mB3-mr-Qcw" customClass="VitaminButton" customModule="Vitamin">
+                                        <rect key="frame" x="0.0" y="63" width="54" height="34"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="18"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Button">
+                                            <color key="titleColor" systemColor="labelColor"/>
+                                        </state>
+                                    </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3T1-Vu-Y5d" customClass="VitaminButton" customModule="Vitamin">
+                                        <rect key="frame" x="84" y="63" width="54" height="34"/>
+                                        <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                                        <state key="normal" title="Button">
+                                            <color key="titleColor" systemColor="labelColor"/>
+                                        </state>
+                                    </button>
+                                </subviews>
+                            </stackView>
                         </subviews>
                     </stackView>
                 </subviews>
@@ -45,7 +65,9 @@
             </tableViewCellContentView>
             <connections>
                 <outlet property="largeButton" destination="wmJ-0t-lzC" id="Jm9-4K-gse"/>
+                <outlet property="largeIconAloneButton" destination="3T1-Vu-Y5d" id="1hz-1n-NL9"/>
                 <outlet property="mediumButton" destination="riL-iH-YB3" id="sYZ-in-0qP"/>
+                <outlet property="mediumIconAloneButton" destination="mB3-mr-Qcw" id="6WS-0R-SL8"/>
             </connections>
             <point key="canvasLocation" x="-123" y="1"/>
         </tableViewCell>

--- a/Sources/VitaminUIKit/Components/Button/README.md
+++ b/Sources/VitaminUIKit/Components/Button/README.md
@@ -29,15 +29,15 @@ You can put an icon from Vitamin icons library in your button, or also have a sq
 To achieve this, `VitaminButton` provides you with a `setIconType(:for:)` method.
 You can have different icons, or even different icon types per state.
 
-`IconType` has four cases :
-- `.leading` : icon will be put before your button label
-- `.trailing` : icon will be put after your button label
-- `.alone` : button will be squared, an icon will be centered, and no button label will be displayed
-- `.none` : no icon will be displayed in your button
+`IconType` has four cases:
+- `.leading`: icon will be put before your button label
+- `.trailing`: icon will be put after your button label
+- `.alone`: button will be squared, an icon will be centered, and no button label will be displayed
+- `.none`: no icon will be displayed in your button
 
-For `.leading`, `.trailing` and `.alone`, you must provide :
+For `.leading`, `.trailing` and `.alone`, you must provide:
 - an `UIImage` from Vitamin icons library (but will work with any UIImage)
-- an optional `UIImage.RenderingMode` : if you provide one, image will be resized using this rendering mode, if not, image will be used as is (with unexpected behaviour if your image has a wrong size)
+- an optional `UIImage.RenderingMode`: if you provide one, image will be resized using this rendering mode, if not, image will be used as is (with unexpected behaviour if your image has a wrong size)
 
 If you do not specify specific icon type for a specific state, the one for .normal state will be chosen.
 And by default, the icon type for .normal state is .none

--- a/Sources/VitaminUIKit/Components/Button/README.md
+++ b/Sources/VitaminUIKit/Components/Button/README.md
@@ -22,3 +22,39 @@ A good example of that would be to make your button stretched to fit its parent'
 Note: `VitaminButton` styles its title as  `TextStyle.xxxbutton`, so make sure you setup the Roboto fonts properly.
 
 If you create your button through Storyboard or Xib, do not forget to set its type to `Custom` (instead of `System`, which is the default value). If not set to `Custom`, `VitaminButton` may act oddly in some circumstances.
+
+### Icon management
+You can put an icon from Vitamin icons library in your button, or also have a square button with only one icon.
+
+To achieve this, `VitaminButton` provides you with a `setIconType(:for:)` method.
+You can have different icons, or even different icon types per state.
+
+`IconType` has four cases :
+- `.leading` : icon will be put before your button label
+- `.trailing` : icon will be put after your button label
+- `.alone` : button will be squared, an icon will be centered, and no button label will be displayed
+- `.none` : no icon will be displayed in your button
+
+For `.leading`, `.trailing` and `.alone`, you must provide :
+- an `UIImage` from Vitamin icons library (but will work with any UIImage)
+- an optional `UIImage.RenderingMode` : if you provide one, image will be resized using this rendering mode, if not, image will be used as is (with unexpected behaviour if your image has a wrong size)
+
+If you do not specify specific icon type for a specific state, the one for .normal state will be chosen.
+And by default, the icon type for .normal state is .none
+
+Note: squareness of VitaminButton with `.alone` is handled through intrisicSize, it is not guaranteed if you apply constants that could impact width and height of button.
+
+```swift
+import Vitamin
+
+// This button will have a white background with a dark border
+// and an apple logo before text (in every state, since only .normal state has been set)
+let button = VitaminButton(style: .secondary)
+button.setIconType(.trailing(image: Vitamix.Line.Logos.apple.image, renderingMode: .alwaysTemplate), for: .normal)
+
+// This button will be square, have a blue background and a white icon centered
+// icon will be an Apple logo in normal state, and an Android logo in .highlighted state
+let button2 = VitaminButton(style: .primary)
+button2.setIconType(.trailing(image: Vitamix.Line.Logos.apple.image, renderingMode: .alwaysTemplate), for: .normal)
+button2.setIconType(.trailing(image: Vitamix.Line.Logos.android.image, renderingMode: .alwaysTemplate), for: .highlighted)
+```

--- a/Sources/VitaminUIKit/Components/Button/README.md
+++ b/Sources/VitaminUIKit/Components/Button/README.md
@@ -36,7 +36,7 @@ You can have different icons, or even different icon types per state.
 - `.none`: no icon will be displayed in your button
 
 For `.leading`, `.trailing` and `.alone`, you must provide:
-- an `UIImage` from Vitamin icons library (but will work with any UIImage)
+- an `UIImage` from Vitamin icons library (but will work with any `UIImage`)
 - an optional `UIImage.RenderingMode`: if you provide one, image will be resized using this rendering mode, if not, image will be used as is (with unexpected behaviour if your image has a wrong size)
 
 If you do not specify specific icon type for a specific state, the one for `.normal` state will be chosen.

--- a/Sources/VitaminUIKit/Components/Button/README.md
+++ b/Sources/VitaminUIKit/Components/Button/README.md
@@ -39,8 +39,8 @@ For `.leading`, `.trailing` and `.alone`, you must provide:
 - an `UIImage` from Vitamin icons library (but will work with any UIImage)
 - an optional `UIImage.RenderingMode`: if you provide one, image will be resized using this rendering mode, if not, image will be used as is (with unexpected behaviour if your image has a wrong size)
 
-If you do not specify specific icon type for a specific state, the one for .normal state will be chosen.
-And by default, the icon type for .normal state is .none
+If you do not specify specific icon type for a specific state, the one for `.normal` state will be chosen.
+And by default, the icon type for `.normal` state is `.none`.
 
 Note: squareness of VitaminButton with `.alone` is handled through intrisicSize, it is not guaranteed if you apply constants that could impact width and height of button.
 

--- a/Sources/VitaminUIKit/Components/Button/VitaminButton+Deprecated.swift
+++ b/Sources/VitaminUIKit/Components/Button/VitaminButton+Deprecated.swift
@@ -1,0 +1,25 @@
+//
+//  Vitamin iOS
+//  Apache License 2.0
+//
+
+import UIKit
+
+extension VitaminButton {
+    @available(*, deprecated, message: "Use setIconType(:for:) instead")
+    public func setLeadingImage(_ image: UIImage, for state: UIControl.State) {
+        setIconType(.leading(image: image, renderingMode: nil), for: state)
+    }
+    @available(*, deprecated, message: "Use setIconType(:for:) instead")
+    public func setTrailingImage(_ image: UIImage, for state: UIControl.State) {
+        setIconType(.trailing(image: image, renderingMode: nil), for: state)
+    }
+    @available(*, deprecated, message: "Use setIconType(:for:) instead")
+    public func setLeadingImage(_ image: UIImage, for state: UIControl.State, renderingMode: UIImage.RenderingMode) {
+        setIconType(.leading(image: image, renderingMode: renderingMode), for: state)
+    }
+    @available(*, deprecated, message: "Use setIconType(:for:) instead")
+    public func setTrailingImage(_ image: UIImage, for state: UIControl.State, renderingMode: UIImage.RenderingMode) {
+        setIconType(.trailing(image: image, renderingMode: renderingMode), for: state)
+    }
+}

--- a/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
+++ b/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
@@ -33,15 +33,15 @@ public class VitaminButton: UIButton {
             applyNewTextStyle()
         }
     }
-    
+
     public enum IconType {
         case trailing(image: UIImage, renderingMode: UIImage.RenderingMode?)
         case leading(image: UIImage, renderingMode: UIImage.RenderingMode?)
         case alone(image: UIImage, renderingMode: UIImage.RenderingMode?)
         case none
     }
-    
-    private var iconTypes: [UIControl.State:IconType] = [.normal: .none]
+
+    private var iconTypes: [UIControl.State: IconType] = [.normal: .none]
 
     public override var isEnabled: Bool {
         didSet {
@@ -64,7 +64,6 @@ public class VitaminButton: UIButton {
         super.init(frame: .zero)
         applyNewStyle()
         applyNewTextStyle()
-        
     }
 
     public required init?(coder: NSCoder) {
@@ -85,7 +84,7 @@ public class VitaminButton: UIButton {
             height: 2 * size.verticalInset(iconType: getIconType(for: self.state)) + baseSize.height
         )
     }
-    
+
     public override func setTitle(_ title: String?, for state: UIControl.State) {
         super.setTitle(title, for: state)
         applyNewTextStyle()
@@ -260,31 +259,29 @@ extension VitaminButton.Size {
     }
 
     func horizontalInset(iconType: VitaminButton.IconType) -> CGFloat {
-        if case .alone(_, _) = iconType {
+        if case .alone = iconType {
             return 12
         }
-        
+
         switch self {
         case .medium: return 20
         case .large: return 40
         }
-        
-        
     }
 
     func verticalInset(iconType: VitaminButton.IconType) -> CGFloat {
-        if case .alone(_, _) = iconType {
+        if case .alone = iconType {
             return 12
         }
-    
+
         switch self {
         case .medium: return 16
         case .large: return 20
         }
     }
-    
+
     func defaultIconSize(iconType: VitaminButton.IconType) -> CGFloat {
-        if case .alone(_, _) = iconType {
+        if case .alone = iconType {
             switch self {
             case .medium : return 24
             case .large: return 32
@@ -301,37 +298,37 @@ extension VitaminButton.Size {
 // - MARK: Icon managemant
 
 extension VitaminButton {
-    public func setIconType(_ iconType: IconType, for state: UIControl.State){
+    public func setIconType(_ iconType: IconType, for state: UIControl.State) {
         iconTypes[state] = iconType
         applyIcon(for: state)
     }
-    
+
     public func getIconType(for state: UIControl.State) -> IconType {
         guard let iconType = iconTypes[state] else {
             return iconTypes[.normal] ?? .none
         }
         return iconType
     }
-    
+
     private func applyIcon(for state: UIControl.State) {
         self.invalidateIntrinsicContentSize()
         let iconTypeForState = getIconType(for: state)
         switch iconTypeForState {
         case .none:
             break
-        case .trailing(let image, let renderingMode):
+        case let .trailing(image, renderingMode):
             self.commonApplyIcon(
                 image: image,
                 iconType: iconTypeForState,
                 state: state,
                 renderingMode: renderingMode)
-        case .leading(let image, let renderingMode):
+        case let .leading(image, renderingMode):
             self.commonApplyIcon(
                 image: image,
                 iconType: iconTypeForState,
                 state: state,
                 renderingMode: renderingMode)
-        case .alone(let image, let renderingMode):
+        case let .alone(image, renderingMode):
             self.setTitle("", for: state)
             self.commonApplyIcon(
                 image: image,
@@ -340,13 +337,16 @@ extension VitaminButton {
                 renderingMode: renderingMode)
         }
     }
-    
+
     private func commonApplyIcon(image: UIImage, iconType: IconType, state: UIControl.State, renderingMode: UIImage.RenderingMode?) {
         var imageUpdated = image
         if let renderingMode = renderingMode {
             guard let resizedImage = image
-                .resizedImage(size: CGSize(width: self.size.defaultIconSize(iconType: getIconType(for: state)), height: self.size.defaultIconSize(iconType: getIconType(for: state))))?
-                    .withRenderingMode(renderingMode) else { return }
+                .resizedImage(
+                    size: CGSize(
+                        width: self.size.defaultIconSize(iconType: getIconType(for: state)),
+                        height: self.size.defaultIconSize(iconType: getIconType(for: state))))?
+                .withRenderingMode(renderingMode) else { return }
             imageUpdated = resizedImage
         }
         self.setImage(imageUpdated, for: state)
@@ -358,16 +358,16 @@ extension VitaminButton {
         self.contentMode = .center
         self.imageView?.contentMode = .scaleAspectFit
     }
-    
+
     private func updateSemantic() {
-        if case .trailing(_, _) = getIconType(for: self.state){
+        if case .trailing = getIconType(for: self.state) {
             self.semanticContentAttribute = .forceRightToLeft
         } else {
             self.semanticContentAttribute = .forceLeftToRight
         }
     }
-    
-    private func updateImageInsets(){
+
+    private func updateImageInsets() {
         self.imageEdgeInsets = self.getIconType(for: self.state).imageEdgeInsets
     }
 }
@@ -375,18 +375,18 @@ extension VitaminButton {
 extension VitaminButton.IconType {
     var imageEdgeInsets: UIEdgeInsets {
         switch self {
-        case .alone(_, _), .none:
+        case .alone, .none:
             return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
-        case .trailing(_, _):
+        case .trailing:
             return UIEdgeInsets(top: 0, left: 10, bottom: 0, right: 0)
-        case .leading(_, _):
+        case .leading:
             return UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 10)
         }
     }
 }
 
 extension UIControl.State: Hashable {
-    public var hashValue: Int {
-        self.rawValue.hashValue
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(self.rawValue.hashValue)
     }
 }

--- a/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
+++ b/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
@@ -329,7 +329,7 @@ extension VitaminButton {
                 state: state,
                 renderingMode: renderingMode)
         case let .alone(image, renderingMode):
-            self.setTitle("", for: state)
+            self.setTitle(nil, for: state)
             self.commonApplyIcon(
                 image: image,
                 iconType: iconTypeForState,


### PR DESCRIPTION
## Changes description
I added the ability to define a 'icon Alone' version of VitaminButton.
I also reworked the way to specify which type of icon you want (for already existing trailing and leading icons)
And I took advantage of this PR to change icon size on large and medium button (see #74)

## Context
- This PR solves #52
- It also solves #74

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] I have tested on an iPad device/simulator.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
- No
I deprecated some methods, but they are still usable, the will just raise a warning.

## Screenshots

#### iPhone
<!--- Put your iPhone screenshots here. -->
![Simulator Screen Shot - iPhone 8 - 2022-07-22 at 17 43 28](https://user-images.githubusercontent.com/43171132/180477983-168351e6-8671-4642-a9a4-d119c83b43b6.png)
![Simulator Screen Shot - iPhone 8 - 2022-07-22 at 17 43 47](https://user-images.githubusercontent.com/43171132/180478068-9622eb90-ad29-4d24-ad39-e68080e44697.png)

#### iPad
<!--- Put your iPad screenshots here. -->
![Simulator Screen Shot - iPad (9th generation) - 2022-07-22 at 17 55 30](https://user-images.githubusercontent.com/43171132/180478113-24c5f240-f8da-4e05-a010-a78eaa2ff011.png)
![Simulator Screen Shot - iPad (9th generation) - 2022-07-22 at 17 56 01](https://user-images.githubusercontent.com/43171132/180478122-f81d3233-d730-4594-82a5-f446966a46f8.png)


## Other information
I am not sure it is Vitamin compliant, but I reworked the code to give the ability to have different icons for different states (that was allowed before by the previous code, but did not work well)
