### PR TITLE
feat: Adding helper to use Custom Fonts on SwiftUI previews

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,9 +34,7 @@ let package = Package(
             resources: [
                 .process("Foundations/Assets/VitaminAssets.xcassets"),
                 .process("Foundations/Icons/Vitamix.xcassets"),
-                .process("Foundations/Typography/Fonts/Roboto-Bold.ttf"),
-                .process("Foundations/Typography/Fonts/Roboto-Regular.ttf"),
-                .process("Foundations/Typography/Fonts/RobotoCondensed-BoldItalic.ttf")
+                .process("Foundations/Typography/Fonts")
             ]),
         .target(
             name: "Vitamin",

--- a/Sources/VitaminSwiftUI/Utils/View/View+Preview.swift
+++ b/Sources/VitaminSwiftUI/Utils/View/View+Preview.swift
@@ -1,0 +1,19 @@
+//
+//  Vitamin iOS
+//  Apache License 2.0
+//
+
+#if arch(x86_64) || arch(arm64)
+import SwiftUI
+import VitaminCore
+
+@available(iOS 13, *)
+extension View {
+    /// Attach this to any Xcode Preview's view to have custom fonts displayed
+    /// Note: Not needed for the actual app
+    public func loadCustomFontsForPreview() -> some View {
+        VitaminFontFamily.registerAllCustomFonts()
+        return self
+    }
+}
+#endif


### PR DESCRIPTION
## Changes description

This PR adds a helper to be able to use custom fonts in SwiftUI preview (only on Xcode 14 for now)

## Context

Until now using custom fonts on SwiftUI previews breaks the preview (crash)

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] I have tested on an iPad device/simulator.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
