### PR TITLE
fix: crash with country flags

### DIFF
--- a/Sources/VitaminCore/Foundations/Assets/VitaminAssets+Flags.swift
+++ b/Sources/VitaminCore/Foundations/Assets/VitaminAssets+Flags.swift
@@ -10,7 +10,11 @@ extension VitaminAssets {
     /// - Parameter countryCode: alpha-2 country code (ISO 3166-1).
     /// - Returns: The country flag in `VitaminAsset` object.
     public static func flag(countryCode: String) -> VitaminAsset? {
-        VitaminAsset(name: countryCode.uppercased())
+        let asset = VitaminAsset(name: countryCode.uppercased())
+        guard asset.optionalImage != nil else {
+            return nil
+        }
+        return asset
     }
 }
 

--- a/Sources/VitaminCore/Foundations/Assets/VitaminAssets.swift
+++ b/Sources/VitaminCore/Foundations/Assets/VitaminAssets.swift
@@ -310,16 +310,20 @@ public struct VitaminAsset {
   public fileprivate(set) var name: String
 
   public var image: UIImage {
+    guard let resultImage = optionalImage else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return resultImage
+  }
+
+  public var optionalImage: UIImage? {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
     let resultImage = UIImage(named: name, in: bundle, compatibleWith: nil)
     #elseif os(watchOS)
     let resultImage = UIImage(named: name)
     #endif
-    guard let result = resultImage else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
+    return resultImage
   }
 }
 

--- a/Sources/VitaminCore/Foundations/Icons/Vitamix.swift
+++ b/Sources/VitaminCore/Foundations/Icons/Vitamix.swift
@@ -518,16 +518,20 @@ public struct VitaminImageAsset {
   public fileprivate(set) var name: String
 
   public var image: UIImage {
+    guard let resultImage = optionalImage else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return resultImage
+  }
+
+  public var optionalImage: UIImage? {
     let bundle = BundleToken.bundle
     #if os(iOS) || os(tvOS)
     let resultImage = UIImage(named: name, in: bundle, compatibleWith: nil)
     #elseif os(watchOS)
     let resultImage = UIImage(named: name)
     #endif
-    guard let result = resultImage else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
+    return resultImage
   }
 }
 

--- a/Sources/VitaminCore/Utils/SwiftGen/images.stencil
+++ b/Sources/VitaminCore/Utils/SwiftGen/images.stencil
@@ -79,16 +79,20 @@ import UIKit
   {{accessModifier}} fileprivate(set) var name: String
 
   {{accessModifier}} var image: UIImage {
+    guard let resultImage = optionalImage else {
+      fatalError("Unable to load image asset named \(name).")
+    }
+    return resultImage
+  }
+
+  {{accessModifier}} var optionalImage: UIImage? {
     let bundle = {{param.bundle|default:"BundleToken.bundle"}}
     #if os(iOS) || os(tvOS)
     let resultImage = UIImage(named: name, in: bundle, compatibleWith: nil)
     #elseif os(watchOS)
     let resultImage = UIImage(named: name)
     #endif
-    guard let result = resultImage else {
-      fatalError("Unable to load image asset named \(name).")
-    }
-    return result
+    return resultImage
   }
 }
 


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
I've edited the SwiftGen images template to add a property `optionalImage: UIImage?` to `VitaminAsset` (and `Vitamix`)

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
Currently, there is a crash when trying to access a country flag that doesn't exist.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] I have tested on an iPad device/simulator.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
