### PR TITLE
fix: crash vitamin button ibdesignable

### DIFF
--- a/Showcase/Application/UIKit/Components/Button/Cell/ButtonTableViewCell.swift
+++ b/Showcase/Application/UIKit/Components/Button/Cell/ButtonTableViewCell.swift
@@ -31,7 +31,7 @@ final class ButtonTableViewCell: UITableViewCell {
         }
     }
 
-    func update(for style: VitaminButton.Style, isEnabled: Bool) {
+    func update(for style: VitaminButtonStyle, isEnabled: Bool) {
         mediumButton.style = style
         largeButton.style = style
         mediumIconAloneButton.style = style

--- a/Showcase/Application/UIKit/Components/Tag/Cell/TagTableViewCell.swift
+++ b/Showcase/Application/UIKit/Components/Tag/Cell/TagTableViewCell.swift
@@ -19,7 +19,7 @@ class MonoTagTableViewCell: UITableViewCell {
         delegate: VitaminTagInteractiveDelegate? = nil
     ) {
         fakeView.backgroundColor = VitaminColor.Core.Background.brandSecondary
-        fakeLabel.attributedText = "This is a \(text) tag \(icon != nil ? "with an": "without") icon"
+        fakeLabel.attributedText = "This is a \(text) tag \(icon != nil ? "with an" : "without") icon"
             .styled(as: .callout)
         vitaminTag.label = text
         vitaminTag.variant = variant

--- a/Sources/VitaminCore/Components/Button/VitaminButtonSize.swift
+++ b/Sources/VitaminCore/Components/Button/VitaminButtonSize.swift
@@ -47,12 +47,12 @@ public extension VitaminButtonSize {
     func defaultIconSize(iconType: VitaminButtonIconType) -> CGFloat {
         if case .alone = iconType {
             switch self {
-            case .medium : return 24
+            case .medium: return 24
             case .large: return 32
             }
         } else {
             switch self {
-            case .medium : return 20
+            case .medium: return 20
             case .large: return 24
             }
         }

--- a/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
+++ b/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
@@ -50,6 +50,12 @@ public class VitaminButton: UIButton {
         applyNewTextStyle()
     }
 
+    public override init(frame: CGRect) {
+        super.init(frame: frame)
+        applyNewStyle()
+        applyNewTextStyle()
+    }
+
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         applyNewStyle()

--- a/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
+++ b/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
@@ -7,19 +7,19 @@ import UIKit
 import VitaminCore
 
 public class VitaminButton: UIButton {
-    public var style: Style = .primary {
+    public var style: VitaminButtonStyle = .primary {
         didSet {
             applyNewStyle()
         }
     }
 
-    public var size: Size = .medium {
+    public var size: VitaminButtonSize = .medium {
         didSet {
             applyNewTextStyle()
         }
     }
 
-    private var iconTypes: [UIControl.State: IconType] = [.normal: .none]
+    private var iconTypes: [UIControl.State: VitaminButtonIconType] = [.normal: .none]
 
     public override var isEnabled: Bool {
         didSet {
@@ -37,7 +37,7 @@ public class VitaminButton: UIButton {
         }
     }
 
-    public required init(style: Style) {
+    public required init(style: VitaminButtonStyle) {
         self.style = style
         super.init(frame: .zero)
         applyNewStyle()
@@ -120,12 +120,12 @@ extension VitaminButton {
 // - MARK: Icon managemant
 
 extension VitaminButton {
-    public func setIconType(_ iconType: IconType, for state: UIControl.State) {
+    public func setIconType(_ iconType: VitaminButtonIconType, for state: UIControl.State) {
         iconTypes[state] = iconType
         applyIcon(for: state)
     }
 
-    public func getIconType(for state: UIControl.State) -> IconType {
+    public func getIconType(for state: UIControl.State) -> VitaminButtonIconType {
         guard let iconType = iconTypes[state] else {
             return iconTypes[.normal] ?? .none
         }
@@ -160,7 +160,12 @@ extension VitaminButton {
         }
     }
 
-    private func commonApplyIcon(image: UIImage, iconType: IconType, state: UIControl.State, renderingMode: UIImage.RenderingMode?) {
+    private func commonApplyIcon(
+        image: UIImage,
+        iconType: VitaminButtonIconType,
+        state: UIControl.State,
+        renderingMode: UIImage.RenderingMode?
+    ) {
         var imageUpdated = image
         if let renderingMode = renderingMode {
             guard let resizedImage = image

--- a/Sources/VitaminUIKit/Components/TextField/VitaminTextField.swift
+++ b/Sources/VitaminUIKit/Components/TextField/VitaminTextField.swift
@@ -342,7 +342,7 @@ extension VitaminTextField {
             return
         }
         let bodyRestrictedAttributes: [NSAttributedString.Key: Any] = [
-            .font: font ,
+            .font: font,
             .foregroundColor: self.state.placeholderColor
         ]
         self.textField.attributedPlaceholder = NSAttributedString(


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Add the method `init(frame: CGRect)` to fix the crash.
I also fix warnings in the project.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
We cannot use `VitaminButton` as `IBDesignable` because of a missing method.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
