### PR TITLE
feat: progress bar improvements

### DIFF
--- a/Showcase/Application/UIKit/Components/Progressbar/ProgressbarViewController.swift
+++ b/Showcase/Application/UIKit/Components/Progressbar/ProgressbarViewController.swift
@@ -131,9 +131,10 @@ final class ProgressbarViewController: UITableViewController {
         ProgressbarDemoConfig(variant: .linear(size: .small, style: .empty), withTrack: true, progress: 0.50),
         ProgressbarDemoConfig(variant: .linear(size: .small, style: .empty), withTrack: false, progress: 0.60),
         ProgressbarDemoConfig(
-            variant: .linear(size: .small, style: .empty),
+            variant: .linear(size: .small, style: .labelOnly),
             progressType: .indeterminate,
-            withTrack: true),
+            withTrack: true,
+            leftLabelText: "Example 3S"),
         ProgressbarDemoConfig(
             variant: .linear(size: .small, style: .empty),
             progressType: .indeterminate,
@@ -155,9 +156,10 @@ final class ProgressbarViewController: UITableViewController {
         ProgressbarDemoConfig(variant: .linear(size: .medium, style: .empty), withTrack: true, progress: 0.90),
         ProgressbarDemoConfig(variant: .linear(size: .medium, style: .empty), withTrack: false, progress: 0.80),
         ProgressbarDemoConfig(
-            variant: .linear(size: .medium, style: .empty),
+            variant: .linear(size: .medium, style: .labelOnly),
             progressType: .indeterminate,
-            withTrack: true),
+            withTrack: true,
+            leftLabelText: "Example 3M"),
         ProgressbarDemoConfig(
             variant: .linear(size: .medium, style: .empty),
             progressType: .indeterminate,
@@ -179,9 +181,10 @@ final class ProgressbarViewController: UITableViewController {
         ProgressbarDemoConfig(variant: .linear(size: .large, style: .empty), withTrack: true, progress: 0.50),
         ProgressbarDemoConfig(variant: .linear(size: .large, style: .empty), withTrack: false, progress: 0.60),
         ProgressbarDemoConfig(
-            variant: .linear(size: .large, style: .empty),
+            variant: .linear(size: .large, style: .labelOnly),
             progressType: .indeterminate,
-            withTrack: true),
+            withTrack: true,
+            leftLabelText: "Example 3L"),
         ProgressbarDemoConfig(
             variant: .linear(size: .large, style: .empty),
             progressType: .indeterminate,

--- a/Sources/VitaminUIKit/Components/Progressbar/README.md
+++ b/Sources/VitaminUIKit/Components/Progressbar/README.md
@@ -82,12 +82,13 @@ If the frame is too small, it will be cropped
 The  `VitaminProgressbar` exists in different styles, depending on the `variant`.
 
 For variant `.linear`, it exists in 3 styles, settable through the `style` associated value of the `variant` property :
-- `.percentage` : the progress percentage will be displayed on the top right of the progress bar, and an optional label can be displayed on the top left of the progress bar. This label can be set with the `leftLabelText` property
-- `.empty` : nothing will be displayed except the progress bar
+- `.percentage`: the progress percentage will be displayed on the top right of the progress bar, and an optional label can be displayed on the top left of the progress bar. This label can be set with the `leftLabelText` property
+- `.labelOnly`: an optional label can be displayed on the top left of the progress bar. This label can be set with the `leftLabelText` property
+- `.empty`: nothing will be displayed except the progress bar
 
 For variant `.circular`, it exists in 4 styles, settable through the `style` associated value of the `variant` property :
-- `.percentage` : the progress percentage will be displayed in the center of the progress bar
-- `.image(UIImage)` : a rounded configurable image will be displayed in the center of the progress bar. You must provide an imagge, that will be fitted (i.e. resized, but not stretched) and rounded in the available space in the center of the progressbar. 
+- `.percentage`: the progress percentage will be displayed in the center of the progress bar
+- `.image(UIImage)`: a rounded configurable image will be displayed in the center of the progress bar. You must provide an imagge, that will be fitted (i.e. resized, but not stretched) and rounded in the available space in the center of the progressbar. 
 - `.empty` : nothing will be displayed in the center of the progress bar
 
 You can also decide to display or not the track (i.e. the grey circle behind the progress in `.circular` variant, or the grey line behind the progress in `.linear` variant) by setting the `showTrack` boolean property 
@@ -98,6 +99,8 @@ The progress of a progressbar can have two types : `.determinate` and `.indeterm
 `.indeterminate` means that you do not know the progress of the task represented by the progressbar. So the progressbar keeps animating, until you stop it.
 
 **NOTE**: In `.indeterminate` progress type, no percentage will be displayed, even if `.percentage` style has been set (this configuration is still allowed by the library)
+
+You can easily swicth between `.determinate` and `.indeterminate` on the same progress bar. When you switch, progress of progress bar will automatically be reset to 0. And if you switch from `.indeterminate` to `.determinate`, animation will be automatically stopped.
 
 ### Making a determinate progress bar progress
 Whenever you want to update the progress of a progress bar with `.determinate` progress type, you can change the value of the `progress` property.

--- a/Sources/VitaminUIKit/Components/Progressbar/VitaminProgressbar.swift
+++ b/Sources/VitaminUIKit/Components/Progressbar/VitaminProgressbar.swift
@@ -370,7 +370,7 @@ extension VitaminProgressbar {
                 self.centerImage.isHidden = true
             case .percentage:
                 // Specific case : in indeterminate progress type, nothing will be displayable, thus displayed
-                self.percentageLabel.isHidden = true
+                self.percentageLabel.isHidden = (progressType == .indeterminate)
                 self.centerImage.isHidden = true
             case .image:
                 self.percentageLabel.isHidden = true
@@ -387,6 +387,7 @@ extension VitaminProgressbar {
                 self.percentageLabel.isHidden = true
                 self.leftLabel.isHidden = true
             case .percentage:
+                // Specific case : in indeterminate progress type, nothing will be displayable, thus displayed
                 self.percentageLabel.isHidden = (progressType == .indeterminate)
                 self.leftLabel.isHidden = false
             case .labelOnly:

--- a/Sources/VitaminUIKit/Components/Progressbar/VitaminProgressbarVariant.swift
+++ b/Sources/VitaminUIKit/Components/Progressbar/VitaminProgressbarVariant.swift
@@ -22,10 +22,12 @@ public enum VitaminProgressbarLinearSize {
 
 /// Style of a progress bar
 public enum VitaminProgressbarLinearStyle {
-    /// Only the cicular progress bar will be displayed
+    /// Only the linear progress bar will be displayed
     case empty
     /// The progress percentage will be displayed in the center of the progress bar
     case percentage
+    /// The left label will be displayed above the progress bar
+    case labelOnly
 }
 
 /// Size of the progress bar, that can be `.small`(64pt of diameter) or `.medium` (128pt of diameter)


### PR DESCRIPTION
## Changes description
After integration in a project, I propose small improvements on the progress bar in UIKit version : 
- fix the linear progress bar track width : rounded caps were out of frame, and were hidden if the enclosing view had clipToBounds = true
- add the ability to display a label above `.indeterminate` linear toolbar
- add the ability to easily swicth between `.determinate` and `.indeterminate` progress type 

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
After integration in the connected locker project (Decathlon CSP team), we noticed some little improvements

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] I have tested on an iPad device/simulator.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Screenshots
no need for screenshots

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
Nothing to add
