### PR TITLE
feat: add line break mode option to UIKit VitaminTextStyle

### DIFF
--- a/Sources/VitaminCore/Foundations/Typography/TextStyles.swift
+++ b/Sources/VitaminCore/Foundations/Typography/TextStyles.swift
@@ -140,10 +140,14 @@ extension VitaminTextStyle: RawRepresentable {
 
 extension VitaminTextStyle {
     /// The paragraph style for the current style.
-    private func paragraphStyle(lineHeight: CGFloat) -> NSParagraphStyle {
+    private func paragraphStyle(
+        lineHeight: CGFloat,
+        lineBreakMode: NSLineBreakMode
+    ) -> NSParagraphStyle {
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.minimumLineHeight = lineHeight
         paragraphStyle.maximumLineHeight = lineHeight
+        paragraphStyle.lineBreakMode = lineBreakMode
         return paragraphStyle
     }
 
@@ -199,14 +203,32 @@ extension VitaminTextStyle {
     /// `.font`: The font for the current style.
     /// `.paragraphStyle`: The paragraph style for the current style.
     /// `.baselineOffset`: The baselineOffset for the current style.
+    @available(*, deprecated, renamed: "customAttributes()")
     public var attributes: [NSAttributedString.Key: Any] {
+        customAttributes()
+    }
+
+    /// Customize and get all attributes for the current style.
+    /// - Parameters:
+    ///   - textColor: The color for the text. Optional. Default: `VitaminColor.Core.Content.primary`.
+    ///   - lineBreakMode: The line break mode. Optional. Default: `NSLineBreakMode.byTruncatingTail`.
+    /// - Returns: A dictionary of `NSAttributedString` attributes.
+    ///     `.foregroundColor`: The text color.
+    ///     `.font`: The font for the current style.
+    ///     `.paragraphStyle`: The paragraph style for the current style.
+    ///     `.baselineOffset`: The baselineOffset for the current style.
+    public func customAttributes(
+        textColor: UIColor? = nil,
+        lineBreakMode: NSLineBreakMode? = nil
+    ) -> [NSAttributedString.Key: Any] {
         let adjustedFont = scaledFont
         let adjustedSize = adjustedFont.pointSize
         let adjustedLineHeight = scaledLineHeight(for: adjustedFont)
-        let paragraphStyle = paragraphStyle(lineHeight: adjustedLineHeight)
+        let paragraphStyle = paragraphStyle(lineHeight: adjustedLineHeight,
+                                            lineBreakMode: lineBreakMode ?? .byTruncatingTail)
         let baselineOffset = baselineOffset(lineHeight: adjustedLineHeight, size: adjustedSize)
         return [
-            .foregroundColor: VitaminColor.Core.Content.primary,
+            .foregroundColor: textColor ?? VitaminColor.Core.Content.primary,
             .font: adjustedFont,
             .paragraphStyle: paragraphStyle,
             .baselineOffset: baselineOffset
@@ -221,12 +243,14 @@ extension String {
     /// - Parameters:
     ///   - textStyle: The style that we want to apply.
     ///   - textColor: The color for the text. Optional. Default: `VitaminColor.Core.Content.primary`.
+    ///   - lineBreakMode: The line break mode. Optional. Default: `NSLineBreakMode.byTruncatingTail`.
     /// - Returns: A `NSAttributedString` with all attributes.
-    public func styled(as textStyle: VitaminTextStyle, with textColor: UIColor? = nil) -> NSAttributedString {
-        var attributes = textStyle.attributes
-        if let color = textColor {
-            attributes[.foregroundColor] = color
-        }
+    public func styled(
+        as textStyle: VitaminTextStyle,
+        with textColor: UIColor? = nil,
+        lineBreakMode: NSLineBreakMode? = nil
+    ) -> NSAttributedString {
+        let attributes = textStyle.customAttributes(textColor: textColor, lineBreakMode: lineBreakMode)
         return NSAttributedString(string: self, attributes: attributes)
     }
 }

--- a/Sources/VitaminUIKit/Components/Progressbar/VitaminProgressbarVariant.swift
+++ b/Sources/VitaminUIKit/Components/Progressbar/VitaminProgressbarVariant.swift
@@ -123,7 +123,7 @@ extension VitaminProgressbarLinearSize {
 
     var labelLineHeight: CGFloat {
         // extract lineHeight from text style
-        let paragraphStyle = self.textStyle.attributes[.paragraphStyle] as? NSParagraphStyle
+        let paragraphStyle = self.textStyle.customAttributes()[.paragraphStyle] as? NSParagraphStyle
         let lineHeight = paragraphStyle?.maximumLineHeight
         if let lineHeight = lineHeight {
             return lineHeight

--- a/Sources/VitaminUIKit/Components/TextField/VitaminTextField.swift
+++ b/Sources/VitaminUIKit/Components/TextField/VitaminTextField.swift
@@ -336,7 +336,7 @@ extension VitaminTextField {
         // and color it.
         // By doing this, we let iOS center the text in the TextField, which is
         // what we want in the end
-        guard let font = VitaminTextStyle.body.attributes[.font] else {
+        guard let font = VitaminTextStyle.body.customAttributes()[.font] else {
             // should never happen, .body will always have a .font
             // only used to avoid force unwrap
             return
@@ -374,7 +374,7 @@ extension VitaminTextField {
         // using `typingAttributes` in delegate causes a memory leak
         // and the app does not respond after some time
         // to avoid that, we just pick the font from the .body style, and just apply it
-        guard let font = VitaminTextStyle.body.attributes[.font] as? UIFont else {
+        guard let font = VitaminTextStyle.body.customAttributes()[.font] as? UIFont else {
             return
         }
         textField.font = font

--- a/Sources/VitaminUIKit/Foundations/Typography/README.md
+++ b/Sources/VitaminUIKit/Foundations/Typography/README.md
@@ -10,9 +10,12 @@ Vitamin provides a `TextStyle` enum:
 - `title3`
 - `headline`
 - `body`
+- `bodyBold`
 - `callout`
+- `calloutBold`
 - `subhead`
 - `footnote`
+- `footnoteBold`
 - `caption1`
 - `caption2`
 
@@ -26,5 +29,8 @@ let vitaminStyledTitle = "This is a title".styled(as: .title1)
 let vitaminStyledBody = "This is a body text".styled(as: .body)
 
 let text = "This a is a body text with positive semantic color"
-var vitaminStyleBodySuccess: NSAttributedString = text.styled(as: .body, with:  VitaminColor.Core.Content.positive)
+var vitaminStyleBodySuccess: NSAttributedString = text.styled(as: .body, with: VitaminColor.Core.Content.positive)
+
+let text = "This a is a caption text with custom line break mode"
+var vitaminStyleCaption: NSAttributedString = text.styled(as: .caption1, lineBreakMode: .byWordWrapping)
 ```


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
- [x] Add an option to handle line break in `VitaminTextStyle` for `UIKit`.
- [x] Update the documentation.
- [x] Deprecate a variable.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
Currently the `VitaminTextStyle` doesn't handle line break mode.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No but a variable is now deprecated.

## Screenshots

#### iPhone (it's just for test, it's not the current showcase)
<!--- Put your iPhone screenshots here. -->
![Screenshot](https://user-images.githubusercontent.com/87971589/193834358-9c7e2443-4471-4c52-98ea-c0687469fbba.png)


