### PR TITLE
fix: SwiftUI TextStyle modifier line height

### DIFF
--- a/Sources/VitaminSwiftUI/Foundations/Typography/Typography+SwiftUI.swift
+++ b/Sources/VitaminSwiftUI/Foundations/Typography/Typography+SwiftUI.swift
@@ -13,7 +13,7 @@ struct TextStylesModifier: ViewModifier {
 
     func body(content: Content) -> some View {
         let font = textStyle.scaledFont
-        let lineSpacing = textStyle.lineHeight - textStyle.scaledLineHeight(for: font)
+        let lineSpacing = textStyle.scaledLineHeight(for: font) - font.pointSize
         content
             .font(font.swiftUIFont)
             .lineSpacing(lineSpacing)


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
I fixed the line height calculation to get the correct value.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
The line height when using the `.vitaminTextStyle` modifier was not correct.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] I have tested on an iPad device/simulator.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Screenshots

| Before | After |
| ------- | ---- |
| ![Before](https://user-images.githubusercontent.com/87971589/195650173-1fd9de77-7756-4637-b5f1-d52bb9d39cdc.png) | ![After](https://user-images.githubusercontent.com/87971589/195650214-83c26f39-34b2-4502-88b3-cdcb792feffb.png) |
| With dynamic type enabled | |
| ![Before 1](https://user-images.githubusercontent.com/87971589/195651470-a721380b-ff99-4465-984d-3480dcd97ec1.png) | ![After 1](https://user-images.githubusercontent.com/87971589/195651515-2c9bfc4e-5200-4487-a88f-479ab54fd444.png) |

