### PR TITLE
fix: allow removing horizontal padding on VitaminTextField

### DIFF
--- a/Sources/VitaminUIKit/Components/TextField/README.md
+++ b/Sources/VitaminUIKit/Components/TextField/README.md
@@ -77,7 +77,9 @@ The default style is `.outline`.
 
 You can manually change the `state` property, or you can set the `activeOnEditing` boolean property to `true` to automatically switch the state to `.active` when the field gets the focus (onmy if its state is not `.error`or `.success`).
 
-If you instantiate your `VitaminTextField` programmatically, the `initialState` and `activeOnEditing` properties must be provided through a `VitaminTextField.StateConfiguration` struct.
+You can also decide if your `VitamintextField` should or not have leading and trailing padding, by modifying the boolean `horizontalPadding` property. Its default value is set to `true`, meaning leading and trailing padding are present.
+
+If you instantiate your `VitaminTextField` programmatically, the `initialState`, `activeOnEditing` and `horizontalPadding` properties must be provided through a `VitaminTextField.StateConfiguration` struct.
 
 
 ### Validation

--- a/Sources/VitaminUIKit/Components/TextField/VitaminTextField+Configuration.swift
+++ b/Sources/VitaminUIKit/Components/TextField/VitaminTextField+Configuration.swift
@@ -61,13 +61,16 @@ public extension VitaminTextField {
     struct StateConfiguration {
         public var initialState: VitaminTextField.State
         public var activeOnEditing = false
+        public var horizontalPadding = true
 
         public init(
             initialState: VitaminTextField.State,
-            activeOnEditing: Bool = false
+            activeOnEditing: Bool = false,
+            horizontalPadding: Bool = true
         ) {
             self.initialState = initialState
             self.activeOnEditing = activeOnEditing
+            self.horizontalPadding = horizontalPadding
         }
     }
 

--- a/Sources/VitaminUIKit/Components/TextField/VitaminTextField.swift
+++ b/Sources/VitaminUIKit/Components/TextField/VitaminTextField.swift
@@ -237,8 +237,7 @@ public class VitaminTextField: UIView {
         validation: VitaminTextField.ValidationConfiguration? = nil,
         maxLength: Int? = nil,
         icon: VitaminTextField.IconConfiguration? = nil,
-        textFieldTag: Int = 0,
-        horizontalPadding: Bool = true
+        textFieldTag: Int = 0
     ) {
         super.init(frame: .zero)
         self.style = style
@@ -253,7 +252,7 @@ public class VitaminTextField: UIView {
         self.liveValidationTimeInterval = validation?.liveValidationTimeInterval ?? 0.5
         self.endEditingValidation = validation?.endEditingValidation
         self.activeOnEditing = state.activeOnEditing
-        self.horizontalPadding = horizontalPadding
+        self.horizontalPadding = state.horizontalPadding
         commonInit()
         self.textFieldTag = textFieldTag
         self.fieldValue = texts.fieldValue

--- a/Sources/VitaminUIKit/Components/TextField/VitaminTextField.swift
+++ b/Sources/VitaminUIKit/Components/TextField/VitaminTextField.swift
@@ -13,6 +13,8 @@ public typealias VitaminTextFieldIconAction = (VitaminTextField) -> Void
 public class VitaminTextField: UIView {
     // Constants
     private static let textFieldHeight: CGFloat = 44.0
+    private static let leadingTrailingConstraintConstant: CGFloat = 10.0
+    private static let noLeadingTrailingConstraintConstant: CGFloat = 0.0
 
     /// Enum representing an error during text field validation
     /// It can be of two types
@@ -117,6 +119,13 @@ public class VitaminTextField: UIView {
         }
     }
 
+    /// The presence of leading ad Traling padding beytween elements of VitalinTextField and safearea of the view
+    @IBInspectable public var horizontalPadding: Bool = true {
+        didSet {
+            applyNewHorizontalPadding()
+        }
+    }
+
     /// A closure that allows to validate the `VitaminTextField` every time its value changes
     /// Parameters:
     /// - an optional String containing the new text field value
@@ -204,6 +213,19 @@ public class VitaminTextField: UIView {
     /// Line displayed below `VitaminTextField`in `.filled` state
     @IBOutlet weak var underline: UIView!
 
+    /// Textfiled leading constraint
+    @IBOutlet weak var textFieldLeadingConstraint: NSLayoutConstraint!
+    /// TextField trailing constraint
+    @IBOutlet weak var textFieldTrailingConstraint: NSLayoutConstraint!
+    /// Label leading constraint
+    @IBOutlet weak var labelLeadingConstraint: NSLayoutConstraint!
+    /// Label trailing Consraint
+    @IBOutlet weak var labelTrailingConstraint: NSLayoutConstraint!
+    /// Helper text StackView leading constraint
+    @IBOutlet weak var helperTextStackViewLeadingConstraint: NSLayoutConstraint!
+    /// Helper text StackView trailing constraint
+    @IBOutlet weak var helperTextStackViewTrailingConstraint: NSLayoutConstraint!
+
     // Filename of the nib taht contains the layout of the `VitamineTextField`
     private let nibName = "VitaminTextField"
 
@@ -215,7 +237,8 @@ public class VitaminTextField: UIView {
         validation: VitaminTextField.ValidationConfiguration? = nil,
         maxLength: Int? = nil,
         icon: VitaminTextField.IconConfiguration? = nil,
-        textFieldTag: Int = 0
+        textFieldTag: Int = 0,
+        horizontalPadding: Bool = true
     ) {
         super.init(frame: .zero)
         self.style = style
@@ -230,6 +253,7 @@ public class VitaminTextField: UIView {
         self.liveValidationTimeInterval = validation?.liveValidationTimeInterval ?? 0.5
         self.endEditingValidation = validation?.endEditingValidation
         self.activeOnEditing = state.activeOnEditing
+        self.horizontalPadding = horizontalPadding
         commonInit()
         self.textFieldTag = textFieldTag
         self.fieldValue = texts.fieldValue
@@ -260,6 +284,7 @@ public class VitaminTextField: UIView {
         applyNewHelperText()
         applyNewPlaceHolder()
         applyNewIcon()
+        applyNewHorizontalPadding()
         textField.delegate = self
         textField.enclosingVitaminTextField = self
         NotificationCenter.default.addObserver(
@@ -435,6 +460,24 @@ extension VitaminTextField {
     // handling of secure text field
     private func applySecureTextField() {
         self.textField.isSecureTextEntry = self.isSecureTextEntry
+    }
+
+    private func applyNewHorizontalPadding() {
+        if self.horizontalPadding {
+            labelLeadingConstraint.constant = Self.leadingTrailingConstraintConstant
+            labelTrailingConstraint.constant = Self.leadingTrailingConstraintConstant
+            textFieldLeadingConstraint.constant = Self.leadingTrailingConstraintConstant
+            textFieldTrailingConstraint.constant = Self.leadingTrailingConstraintConstant
+            helperTextStackViewLeadingConstraint.constant = Self.leadingTrailingConstraintConstant
+            helperTextStackViewTrailingConstraint.constant = Self.leadingTrailingConstraintConstant
+        } else {
+            labelLeadingConstraint.constant = Self.noLeadingTrailingConstraintConstant
+            labelTrailingConstraint.constant = Self.noLeadingTrailingConstraintConstant
+            textFieldLeadingConstraint.constant = Self.noLeadingTrailingConstraintConstant
+            textFieldTrailingConstraint.constant = Self.noLeadingTrailingConstraintConstant
+            helperTextStackViewLeadingConstraint.constant = Self.noLeadingTrailingConstraintConstant
+            helperTextStackViewTrailingConstraint.constant = Self.noLeadingTrailingConstraintConstant
+        }
     }
 
     /// method that will be called when the user clicks on the iconn

--- a/Sources/VitaminUIKit/Components/TextField/VitaminTextField.xib
+++ b/Sources/VitaminUIKit/Components/TextField/VitaminTextField.xib
@@ -13,8 +13,14 @@
             <connections>
                 <outlet property="counter" destination="Vkg-ne-YMS" id="3xT-JE-rdU"/>
                 <outlet property="helper" destination="uKP-x2-F5I" id="v55-T1-Lcs"/>
+                <outlet property="helperTextStackViewLeadingConstraint" destination="kC2-mh-hEN" id="aJR-9E-bPR"/>
+                <outlet property="helperTextStackViewTrailingConstraint" destination="u8x-dp-Alp" id="zYU-WJ-G3K"/>
                 <outlet property="label" destination="fnF-Hc-8xq" id="S3G-db-daJ"/>
+                <outlet property="labelLeadingConstraint" destination="lDQ-Wy-1Cj" id="PE2-7w-8L6"/>
+                <outlet property="labelTrailingConstraint" destination="Zii-eP-tV4" id="6yi-8b-Zgb"/>
                 <outlet property="textField" destination="W96-KI-6uq" id="EoL-Tb-R3w"/>
+                <outlet property="textFieldLeadingConstraint" destination="fyU-bY-AHW" id="bAM-5w-gAK"/>
+                <outlet property="textFieldTrailingConstraint" destination="hrz-8d-muk" id="Mpz-Gp-flk"/>
                 <outlet property="underline" destination="hLu-Ss-P9n" id="hZF-Bd-uqf"/>
             </connections>
         </placeholder>


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Horizontal leading and trailing padding are added to VitaminTextField.
The aim of this PR is to allow removing these padding if desired (and keeping them by default for retrcompatibility).
For that, a new boolean property named `horizontalPadding` has been added to VitaminTextField.
Its default value is `true` (for backward compatibility), and can be set to false either in constructor, of afterwards.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
Fixes #89 

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [ ] I have tested on an iPad device/simulator.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Screenshots

#### iPhone
<!--- Put your iPhone screenshots here. -->
![simulator_screenshot_C7A9CB4C-0897-4B6D-A443-79CD028EC42A](https://user-images.githubusercontent.com/43171132/196209035-16d8b397-6dbf-451f-b81c-a8e75d96ff1f.png)

#### iPad
<!--- Put your iPad screenshots here. -->
![simulator_screenshot_0CA85E44-3535-4647-AC46-13D9EE03FEB6](https://user-images.githubusercontent.com/43171132/196209578-db3f4682-6b94-48b3-b167-38af42e5afed.png)

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
