### PR TITLE
fix: crash for swiftui color

### DIFF
--- a/Sources/VitaminSwiftUI/Utils/UIColor+SwiftUI.swift
+++ b/Sources/VitaminSwiftUI/Utils/UIColor+SwiftUI.swift
@@ -12,10 +12,13 @@ extension UIColor {
         if #available(iOS 15.0, *) {
             return Color(uiColor: self)
         } else {
-            let components = self.cgColor.components
-            return Color(red: Double(components?[0] ?? 0),
-                         green: Double(components?[1] ?? 0),
-                         blue: Double(components?[2] ?? 0))
+            guard let components = self.cgColor.components,
+                    components.count > 2 else {
+                return Color.clear
+            }
+            return Color(red: Double(components[0]),
+                         green: Double(components[1]),
+                         blue: Double(components[2]))
         }
     }
 }


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Add a condition to avoid code that can crash.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
We have a crash when we try to use a `VitaminButtonUIStyle` on a button with  style `.primary` and `.ghost`.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] I have tested on an iPad device/simulator.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No

## Other information
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. You can also remove this section. -->
N/A