### PR TITLE
fix: enforce title color when title is set to avoid weird behaviours

### DIFF
--- a/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
+++ b/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
@@ -72,6 +72,7 @@ public class VitaminButton: UIButton {
     public override func setTitle(_ title: String?, for state: UIControl.State) {
         super.setTitle(title, for: state)
         applyNewTextStyle()
+        setTitleColor(style.foregroundColor, for: state)
     }
 }
 


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
When title is set, we re-enforce the title color to avoid weird effects like described in #101

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
fixes #101 

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [ ] I have tested on an iPad device/simulator.
- [ ] If it includes design changes, please ask for a review with a core team designer.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
