### PR TITLE
fix: SwiftUI TextField - loop issue with characters counter

### DIFF
--- a/Sources/VitaminSwiftUI/Components/TextField/VitaminTextFieldModifier.swift
+++ b/Sources/VitaminSwiftUI/Components/TextField/VitaminTextFieldModifier.swift
@@ -141,7 +141,10 @@ public struct VitaminTextFieldModifier: ViewModifier {
         content
             .font(VitaminTextStyle.body.scaledFont.swiftUIFont)
             .onReceive(Just(text)) { newValue in
-                text = truncateIfLimit(text: newValue)
+                let truncatedText = truncateIfLimit(text: newValue)
+                if text != truncatedText {
+                    text = truncatedText
+                }
                 counterText = makeCharactersCounterText(newValue)
             }
             .contentShape(Rectangle())


### PR DESCRIPTION
## Changes description
<!--- Describe your changes in details. -->
Now, we update the text value only when the value changes.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an opened issue, please link to the issue here. -->
When we add a counter in the SwiftUI TextField, the text is always updated, even when there is no changes.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] I have tested on an iPad device/simulator.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No