### PR TITLE
chore: bump to 0.10.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,17 @@ For its [Digital section](https://www.decathlon.design/726f8c765/p/6145b2-overvi
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/Decathlon/vitamin-ios.git", .exact("0.9.1"))
+    .package(url: "https://github.com/Decathlon/vitamin-ios.git", .exact("0.10.0"))
 ]
 ```
 
 ### Cocoapods
 ```ruby
 # for UIKitVersion
-pod 'Vitamin', '= 0.9.1'
+pod 'Vitamin', '= 0.10.0'
 
 # for SwiftUI version
-pod 'VitaminSwiftUI', = '0.9.1'
+pod 'VitaminSwiftUI', = '0.10.0'
 ```
 
 ## Available elements

--- a/Vitamin.podspec
+++ b/Vitamin.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Vitamin"
-  s.version      = "0.9.1"
+  s.version      = "0.10.0"
   s.summary      = "The iOS implement of Decathlon's design system"
 
   s.homepage     = "https://github.com/Decathlon/vitamin-ios"

--- a/VitaminCore.podspec
+++ b/VitaminCore.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "VitaminCore"
-  s.version      = "0.9.1"
+  s.version      = "0.10.0"
   s.summary      = "The iOS implement of Decathlon's design system"
 
   s.homepage     = "https://github.com/Decathlon/vitamin-ios"

--- a/VitaminSwiftUI.podspec
+++ b/VitaminSwiftUI.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "VitaminSwiftUI"
-  s.version      = "0.9.1"
+  s.version      = "0.10.0"
   s.summary      = "The iOS implement of Decathlon's design system"
 
   s.homepage     = "https://github.com/Decathlon/vitamin-ios"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -66,7 +66,7 @@ workflows:
             set -e
 
             # register to trunk
-            pod trunk register
+            # pod trunk register
 
             # push to CocoaPods specs
             pod trunk push VitaminCore.podspec --allow-warnings --synchronous

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -65,9 +65,6 @@ workflows:
             # fail if any commands fails
             set -e
 
-            # register to trunk
-            # pod trunk register
-
             # push to CocoaPods specs
             pod trunk push VitaminCore.podspec --allow-warnings --synchronous
             pod trunk push Vitamin.podspec --allow-warnings --synchronous


### PR DESCRIPTION
## Changes description
Reintegrate 0.10.0 tag generated by bitrise workflow to main

## Context
Have the latest version for cocoapods on main

## Checklist
<!--- Feel free to add other steps if needed. -->

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [ ] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [ ] Check your code additions will fail neither code linting checks.
- [ ] I have reviewed the submitted code.
- [ ] I have tested on an iPhone device/simulator.
- [ ] I have tested on an iPad device/simulator.
- [ ] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

- No
