### PR TITLE
fix: UIKit VitaminTextfield text color

### DIFF
--- a/Sources/VitaminCore/Components/TextField/VitaminTextFieldState.swift
+++ b/Sources/VitaminCore/Components/TextField/VitaminTextFieldState.swift
@@ -36,7 +36,7 @@ extension VitaminTextFieldState {
         if self == .disabled {
             return VitaminColor.Core.Content.primary.disabledColor()
         } else {
-            return VitaminColor.Core.Content.tertiary
+            return VitaminColor.Core.Content.primary
         }
     }
 


### PR DESCRIPTION
## Changes description
This PR fixes the text color of the UIKit VitaminTextField component in enable mode.

## Context
The color for enable mode was tertiary instead of primary.
You can see it on the screen below in the first textfield, i tapped "TEST TEST" and the text color is tertiary.

## Checklist
<!--- Feel free to add other steps if needed. -->

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] I have tested on an iPad device/simulator.

## Does this introduce a breaking change?
- No

## Screenshots

#### iPhon
![Simulator Screen Shot - iPhone 14 Pro Max - 2023-02-28 at 18 09 24](https://user-images.githubusercontent.com/74912675/221926737-e6a1e537-047e-4338-a4d5-ceda54f0ffac.png)
e


