### PR TITLE
feat: swiftui fullwidth button

### DIFF
--- a/Showcase/Application/SwiftUI/Components/Button/ButtonsView.swift
+++ b/Showcase/Application/SwiftUI/Components/Button/ButtonsView.swift
@@ -10,12 +10,15 @@ import VitaminCore
 
 @available(iOS 13, *)
 struct ButtonsView: View {
-    @State var enabled = true
+    @State private var enabled = true
+    @State private var fullWidth = false
 
     var body: some View {
         VStack {
-            Toggle("Show enabled state", isOn: $enabled)
-                .padding()
+            VStack {
+                Toggle("Show enabled state", isOn: $enabled.animation())
+                Toggle("Show full width", isOn: $fullWidth.animation())
+            }.padding()
             List {
                 makeButtonRows()
             }
@@ -81,6 +84,7 @@ extension ButtonsView {
             text: style.rawValue,
             style: style,
             size: size,
+            fullWidth: fullWidth,
             iconType: iconType) {
                     // no action defined
         }

--- a/Sources/VitaminSwiftUI/Components/Button/README.md
+++ b/Sources/VitaminSwiftUI/Components/Button/README.md
@@ -17,10 +17,11 @@ struct ExampleView: View {
             VitaminButton(
                 text: "Button",
                 style: .secondary)
-            // This button will have a white background with a dark border
+            // This button will have a white background with a dark border and expand to full width
             VitaminButton(
                 text: "Button",
-                style: .ghost,)
+                style: .ghost,
+                fullWidth: true)
         }
     }
 }
@@ -30,7 +31,7 @@ struct ExampleView: View {
 
 ### Style and Size management
 You must provide `VitaminButton` with a `style` property, which is a `VitaminButtonStyle` enum case.
-Refernce for different styles of button is available in design reference documentation.
+Reference for different styles of button is available in design reference documentation.
 
 Default style is `.primary`.
  
@@ -40,6 +41,8 @@ The size of the `VitaminButton` will adapt itself with the content you provide (
 Default style is `.medium`.
 
 Note: `VitaminButton` styles its title as  `TextStyle.xxxbutton`, so make sure you setup the Roboto fonts properly.
+
+If you set the `fullWidth` property to `true` (default is `false`), the button will expand to full width of its container.
 
 
 ### Icon management

--- a/Sources/VitaminSwiftUI/Components/Button/VitaminButton.swift
+++ b/Sources/VitaminSwiftUI/Components/Button/VitaminButton.swift
@@ -12,6 +12,7 @@ public struct VitaminButton: View {
     var text: String?
     let style: VitaminButtonStyle
     let size: VitaminButtonSize
+    let fullWidth: Bool
     let iconType: IconType
     let action: () -> Void
 
@@ -19,12 +20,14 @@ public struct VitaminButton: View {
         text: String? = nil,
         style: VitaminButtonStyle = .primary,
         size: VitaminButtonSize = .medium,
+        fullWidth: Bool = false,
         iconType: IconType = .none,
         action: @escaping () -> Void
     ) {
             self.text = text
             self.style = style
             self.size = size
+            self.fullWidth = fullWidth
             self.iconType = iconType
             self.action = action
     }
@@ -35,7 +38,10 @@ public struct VitaminButton: View {
         } label: {
             makeLabel()
         }
-        .buttonStyle(VitaminButtonUIStyle(style: style, size: size, iconType: iconType.underlyingUIKitIconType))
+        .buttonStyle(VitaminButtonUIStyle(style: style,
+                                          size: size,
+                                          fullWidth: fullWidth,
+                                          iconType: iconType.underlyingUIKitIconType))
     }
 
     @ViewBuilder
@@ -102,16 +108,19 @@ public struct VitaminButton: View {
 public struct VitaminButtonUIStyle: ButtonStyle {
     let style: VitaminButtonStyle
     let size: VitaminButtonSize
+    let fullWidth: Bool
     let iconType: VitaminButtonIconType
     @Environment(\.isEnabled) private var isEnabled
 
     public init(
         style: VitaminButtonStyle = .primary,
         size: VitaminButtonSize = .medium,
+        fullWidth: Bool = false,
         iconType: VitaminButtonIconType = .none
     ) {
         self.style = style
         self.size = size
+        self.fullWidth = fullWidth
         self.iconType = iconType
     }
 
@@ -125,6 +134,7 @@ public struct VitaminButtonUIStyle: ButtonStyle {
                 leading: size.horizontalInset(iconType: self.iconType),
                 bottom: size.verticalInset(iconType: self.iconType),
                 trailing: size.horizontalInset(iconType: self.iconType)))
+            .frame(maxWidth: fullWidth ? .infinity : nil)
             .background(RoundedRectangle(
                 cornerRadius: size.cornerRadius,
                 style: .continuous)


### PR DESCRIPTION
## Changes description
Add full width support for SwiftUI button

## Context
Currently, SwiftUI button can't be sized to full width using `.frame(maxWidth: .infinity)`.

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] I have tested on an iPad device/simulator.
- [ ] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?
- No