### PR TITLE
fix: set tintAdjustmentMode to .normal

### DIFF
--- a/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
+++ b/Sources/VitaminUIKit/Components/Button/VitaminButton.swift
@@ -180,6 +180,7 @@ extension VitaminButton {
         }
         self.setImage(imageUpdated, for: state)
         self.imageView?.tintColor = style.foregroundColor
+        self.imageView?.tintAdjustmentMode = .normal
         self.tintColor = style.foregroundColor
         self.imageEdgeInsets = iconType.imageEdgeInsets
         self.contentEdgeInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)


### PR DESCRIPTION
## Changes description
Add and set `tintAdjustmentMode` property to `.normal` for the `imageView` of `VitaminButton`

## Context
The image tint color is changing when a `UIAlertController` is presented. Setting `tintAdjustmentMode` to `.normal` fix this problem. 

You can see the change in the before/after provided in the screenshots section of this PR. 

## Checklist

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch**. Please, don't request directly from your main!
- [x] Check commits & PR names matches our requested structure. It must follow the https://www.conventionalcommits.org pattern.
- [x] Check your code additions will fail neither code linting checks.
- [x] I have reviewed the submitted code.
- [x] I have tested on an iPhone device/simulator.
- [x] I have tested on an iPad device/simulator.
- [ ] If it includes design changes, please ask for a review `design-system-core-team-design` GitHub team.

## Does this introduce a breaking change?

- No

## Screenshots

#### iPhone

As you can see below the tint color of the icon stay the same with an AlertController presented.

Before | After
--- | ---
<img src="https://user-images.githubusercontent.com/43273464/223160685-c5b21af1-9ed5-4c23-949d-62be4361a55d.png" width="375" height="667"> | <img src="https://user-images.githubusercontent.com/43273464/223160695-491cf6e1-984d-4c2c-9d73-59175f1d5c97.png" width="375" height="667">
